### PR TITLE
Add account listing and switching commands

### DIFF
--- a/src/__tests__/accounts.test.ts
+++ b/src/__tests__/accounts.test.ts
@@ -1,0 +1,265 @@
+import { test, expect, describe, beforeAll, afterAll, mock } from "bun:test";
+import {
+  connectToSuperhuman,
+  disconnect,
+  type SuperhumanConnection,
+} from "../superhuman-api";
+import { listAccounts, switchAccount, type Account, type SwitchResult } from "../accounts";
+import { formatAccountsList, formatAccountsJson } from "../cli";
+import { accountsHandler, switchAccountHandler } from "../mcp/tools";
+
+const CDP_PORT = 9333;
+
+describe("accounts", () => {
+  let conn: SuperhumanConnection | null = null;
+
+  beforeAll(async () => {
+    conn = await connectToSuperhuman(CDP_PORT);
+    if (!conn) {
+      throw new Error(
+        "Could not connect to Superhuman. Make sure it is running with --remote-debugging-port=9333"
+      );
+    }
+  });
+
+  afterAll(async () => {
+    if (conn) {
+      await disconnect(conn);
+    }
+  });
+
+  test("listAccounts returns array of accounts", async () => {
+    if (!conn) throw new Error("No connection");
+
+    const accounts = await listAccounts(conn);
+
+    // Should return an array
+    expect(Array.isArray(accounts)).toBe(true);
+
+    // Should have at least one account
+    expect(accounts.length).toBeGreaterThan(0);
+
+    // Verify account structure
+    const account = accounts[0];
+    expect(account).toHaveProperty("email");
+    expect(account).toHaveProperty("isCurrent");
+    expect(typeof account.email).toBe("string");
+    expect(typeof account.isCurrent).toBe("boolean");
+
+    // Email should be non-empty and look like an email
+    expect(account.email.length).toBeGreaterThan(0);
+    expect(account.email).toContain("@");
+  });
+
+  test("exactly one account is marked as current", async () => {
+    if (!conn) throw new Error("No connection");
+
+    const accounts = await listAccounts(conn);
+
+    // Exactly one account should have isCurrent=true
+    const currentAccounts = accounts.filter((a) => a.isCurrent);
+    expect(currentAccounts.length).toBe(1);
+  });
+
+  test("switchAccount switches to a different account", async () => {
+    if (!conn) throw new Error("No connection");
+
+    // Get current accounts
+    const accounts = await listAccounts(conn);
+    expect(accounts.length).toBeGreaterThan(1); // Need at least 2 accounts to switch
+
+    // Find current account and a different account to switch to
+    const currentAccount = accounts.find((a) => a.isCurrent);
+    const targetAccount = accounts.find((a) => !a.isCurrent);
+
+    if (!currentAccount || !targetAccount) {
+      throw new Error("Need at least 2 accounts to test switching");
+    }
+
+    // Switch to the target account
+    const result = await switchAccount(conn, targetAccount.email);
+
+    // Verify the switch was successful
+    expect(result.success).toBe(true);
+    expect(result.email).toBe(targetAccount.email);
+
+    // Verify via listAccounts that the switch occurred
+    const accountsAfter = await listAccounts(conn);
+    const newCurrent = accountsAfter.find((a) => a.isCurrent);
+    expect(newCurrent?.email).toBe(targetAccount.email);
+  });
+
+  test("switchAccount round-trip returns to original account", async () => {
+    if (!conn) throw new Error("No connection");
+
+    // Get current accounts (note: after previous test, current may have changed)
+    const accounts = await listAccounts(conn);
+    expect(accounts.length).toBeGreaterThan(1);
+
+    const currentAccount = accounts.find((a) => a.isCurrent);
+    const targetAccount = accounts.find((a) => !a.isCurrent);
+
+    if (!currentAccount || !targetAccount) {
+      throw new Error("Need at least 2 accounts to test switching");
+    }
+
+    // Switch to target
+    const result1 = await switchAccount(conn, targetAccount.email);
+    expect(result1.success).toBe(true);
+    expect(result1.email).toBe(targetAccount.email);
+
+    // Switch back to original
+    const result2 = await switchAccount(conn, currentAccount.email);
+    expect(result2.success).toBe(true);
+    expect(result2.email).toBe(currentAccount.email);
+  });
+});
+
+describe("CLI formatting functions", () => {
+  const mockAccounts: Account[] = [
+    { email: "eddyhu@gmail.com", isCurrent: false },
+    { email: "ehu@law.virginia.edu", isCurrent: true },
+    { email: "eh2889@nyu.edu", isCurrent: false },
+  ];
+
+  describe("formatAccountsList", () => {
+    test("formats accounts with 1-based index and current marker", () => {
+      const output = formatAccountsList(mockAccounts);
+      const lines = output.split("\n");
+
+      expect(lines.length).toBe(3);
+      expect(lines[0]).toBe("  1. eddyhu@gmail.com");
+      expect(lines[1]).toBe("* 2. ehu@law.virginia.edu (current)");
+      expect(lines[2]).toBe("  3. eh2889@nyu.edu");
+    });
+
+    test("handles empty accounts array", () => {
+      const output = formatAccountsList([]);
+      expect(output).toBe("");
+    });
+
+    test("handles single account that is current", () => {
+      const output = formatAccountsList([{ email: "test@example.com", isCurrent: true }]);
+      expect(output).toBe("* 1. test@example.com (current)");
+    });
+  });
+
+  describe("formatAccountsJson", () => {
+    test("formats accounts as valid JSON array", () => {
+      const output = formatAccountsJson(mockAccounts);
+      const parsed = JSON.parse(output);
+
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed.length).toBe(3);
+      expect(parsed[0]).toEqual({ email: "eddyhu@gmail.com", isCurrent: false });
+      expect(parsed[1]).toEqual({ email: "ehu@law.virginia.edu", isCurrent: true });
+      expect(parsed[2]).toEqual({ email: "eh2889@nyu.edu", isCurrent: false });
+    });
+
+    test("handles empty accounts array", () => {
+      const output = formatAccountsJson([]);
+      expect(output).toBe("[]");
+    });
+  });
+});
+
+describe("MCP account handlers", () => {
+  let conn: SuperhumanConnection | null = null;
+
+  beforeAll(async () => {
+    conn = await connectToSuperhuman(CDP_PORT);
+    if (!conn) {
+      throw new Error(
+        "Could not connect to Superhuman. Make sure it is running with --remote-debugging-port=9333"
+      );
+    }
+  });
+
+  afterAll(async () => {
+    if (conn) {
+      await disconnect(conn);
+    }
+  });
+
+  describe("accountsHandler", () => {
+    test("returns ToolResult with accounts list", async () => {
+      const result = await accountsHandler({});
+
+      // Should return a ToolResult object
+      expect(result).toHaveProperty("content");
+      expect(Array.isArray(result.content)).toBe(true);
+      expect(result.content.length).toBeGreaterThan(0);
+      expect(result.content[0]).toHaveProperty("type", "text");
+      expect(result.content[0]).toHaveProperty("text");
+
+      // Should not be an error
+      expect(result.isError).toBeUndefined();
+
+      // Should contain account info in the text
+      const text = result.content[0].text;
+      expect(text).toContain("@"); // Should have email addresses
+    });
+
+    test("marks current account in output", async () => {
+      const result = await accountsHandler({});
+      const text = result.content[0].text;
+
+      // Should have a current marker
+      expect(text).toContain("(current)");
+    });
+  });
+
+  describe("switchAccountHandler", () => {
+    test("switches account by email address", async () => {
+      // First get accounts to find a target
+      const accounts = await listAccounts(conn!);
+      expect(accounts.length).toBeGreaterThan(1);
+
+      const targetAccount = accounts.find((a) => !a.isCurrent);
+      if (!targetAccount) {
+        throw new Error("Need at least 2 accounts to test switching");
+      }
+
+      const result = await switchAccountHandler({ account: targetAccount.email });
+
+      // Should return success
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain("Switched to");
+      expect(result.content[0].text).toContain(targetAccount.email);
+    });
+
+    test("switches account by index (1-based)", async () => {
+      // Get accounts to know what index to use
+      const accounts = await listAccounts(conn!);
+      expect(accounts.length).toBeGreaterThan(1);
+
+      const currentIndex = accounts.findIndex((a) => a.isCurrent);
+      // Pick a different index (1-based)
+      const targetIndex = currentIndex === 0 ? 2 : 1;
+      const targetEmail = accounts[targetIndex - 1].email;
+
+      const result = await switchAccountHandler({ account: String(targetIndex) });
+
+      // Should return success
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain("Switched to");
+      expect(result.content[0].text).toContain(targetEmail);
+    });
+
+    test("returns error for invalid account identifier", async () => {
+      const result = await switchAccountHandler({ account: "nonexistent@example.com" });
+
+      // Should be an error
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("not found");
+    });
+
+    test("returns error for out-of-range index", async () => {
+      const result = await switchAccountHandler({ account: "999" });
+
+      // Should be an error
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("not found");
+    });
+  });
+});

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -1,0 +1,124 @@
+/**
+ * Accounts Module
+ *
+ * Functions for listing and managing linked accounts in Superhuman.
+ */
+
+import type { SuperhumanConnection } from "./superhuman-api";
+
+export interface Account {
+  email: string;
+  isCurrent: boolean;
+}
+
+export interface SwitchResult {
+  success: boolean;
+  email: string; // current account after switch attempt
+}
+
+/**
+ * List all linked accounts in Superhuman
+ */
+export async function listAccounts(
+  conn: SuperhumanConnection
+): Promise<Account[]> {
+  const { Runtime } = conn;
+
+  const result = await Runtime.evaluate({
+    expression: `
+      (() => {
+        try {
+          // Get list of all linked accounts
+          const accountList = window.GoogleAccount?.accountList?.() || [];
+
+          // Get current account email
+          const currentEmail = window.GoogleAccount?.emailAddress || '';
+
+          // Map to Account objects with isCurrent flag
+          return accountList.map(email => ({
+            email,
+            isCurrent: email === currentEmail,
+          }));
+        } catch (e) {
+          return [];
+        }
+      })()
+    `,
+    returnByValue: true,
+  });
+
+  return (result.result.value as Account[]) || [];
+}
+
+/**
+ * Switch to a different linked account in Superhuman
+ *
+ * This function navigates to the account-specific URL which triggers the
+ * account switch. It then waits for the page to load and verifies the switch.
+ *
+ * @param conn - The Superhuman connection
+ * @param targetEmail - The email address of the account to switch to
+ * @returns SwitchResult with success status and current email after switch
+ */
+export async function switchAccount(
+  conn: SuperhumanConnection,
+  targetEmail: string
+): Promise<SwitchResult> {
+  const { Runtime, Page } = conn;
+
+  // Navigate to the account-specific URL
+  const targetUrl = `https://mail.superhuman.com/${targetEmail}`;
+  await Page.navigate({ url: targetUrl });
+
+  // Wait a moment for navigation to start
+  await new Promise((resolve) => setTimeout(resolve, 500));
+
+  // Poll to verify the switch completed (up to 10 seconds)
+  const maxAttempts = 50;
+  const pollIntervalMs = 200;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      const checkResult = await Runtime.evaluate({
+        expression: `
+          (() => {
+            try {
+              // Check if GoogleAccount is available (page has loaded)
+              if (!window.GoogleAccount || !window.GoogleAccount.emailAddress) {
+                return { ready: false, email: null };
+              }
+              return { ready: true, email: window.GoogleAccount.emailAddress };
+            } catch (e) {
+              return { ready: false, email: null };
+            }
+          })()
+        `,
+        returnByValue: true,
+      });
+
+      const result = checkResult.result.value as { ready: boolean; email: string | null };
+
+      if (result.ready && result.email === targetEmail) {
+        return { success: true, email: result.email };
+      }
+    } catch {
+      // CDP call failed - page might still be loading, continue polling
+    }
+
+    // Wait before next poll
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+  }
+
+  // Timeout - try to get the current email to report what we ended up with
+  try {
+    const finalResult = await Runtime.evaluate({
+      expression: `window.GoogleAccount?.emailAddress || ''`,
+      returnByValue: true,
+    });
+
+    const finalEmail = finalResult.result.value as string;
+    return { success: finalEmail === targetEmail, email: finalEmail };
+  } catch {
+    return { success: false, email: "" };
+  }
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -8,7 +8,9 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
   DraftSchema, SendSchema, SearchSchema, InboxSchema, ReadSchema,
-  draftHandler, sendHandler, searchHandler, inboxHandler, readHandler
+  AccountsSchema, SwitchAccountSchema,
+  draftHandler, sendHandler, searchHandler, inboxHandler, readHandler,
+  accountsHandler, switchAccountHandler
 } from "./tools";
 
 function createMcpServer(): McpServer {
@@ -60,6 +62,24 @@ function createMcpServer(): McpServer {
       inputSchema: ReadSchema,
     },
     readHandler
+  );
+
+  server.registerTool(
+    "superhuman_accounts",
+    {
+      description: "List all linked email accounts in Superhuman. Returns accounts with current marker.",
+      inputSchema: AccountsSchema,
+    },
+    accountsHandler
+  );
+
+  server.registerTool(
+    "superhuman_switch_account",
+    {
+      description: "Switch to a different linked email account in Superhuman. Accepts either an email address or a 1-based index number.",
+      inputSchema: SwitchAccountSchema,
+    },
+    switchAccountHandler
   );
 
   return server;

--- a/src/superhuman-api.ts
+++ b/src/superhuman-api.ts
@@ -11,6 +11,7 @@ export interface SuperhumanConnection {
   Runtime: CDP.Client["Runtime"];
   Input: CDP.Client["Input"];
   Network: CDP.Client["Network"];
+  Page: CDP.Client["Page"];
 }
 
 export interface DraftState {
@@ -46,11 +47,16 @@ export async function connectToSuperhuman(
   }
 
   const client = await CDP({ target: mainPage.id, port });
+
+  // Enable Page domain for navigation events
+  await client.Page.enable();
+
   return {
     client,
     Runtime: client.Runtime,
     Input: client.Input,
     Network: client.Network,
+    Page: client.Page,
   };
 }
 


### PR DESCRIPTION
## Summary
- Add `accounts` command to list all linked accounts with current marker (*)
- Add `account` command to switch by 1-based index or email address
- Add MCP tools: `superhuman_accounts`, `superhuman_switch_account`
- Support `--json` flag for scripted use

## Test plan
- [x] `bun test` passes (19 tests)
- [x] Verified account switching by creating drafts in each account
- [x] User confirmed drafts appear in correct accounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)