### PR TITLE
Add reply, reply-all, and forward commands

### DIFF
--- a/src/__tests__/reply.test.ts
+++ b/src/__tests__/reply.test.ts
@@ -1,0 +1,250 @@
+import { test, expect, describe, beforeAll, afterAll } from "bun:test";
+import {
+  connectToSuperhuman,
+  disconnect,
+  getDraftState,
+  closeCompose,
+  type SuperhumanConnection,
+} from "../superhuman-api";
+import { listInbox } from "../inbox";
+import { readThread } from "../read";
+import { replyToThread, replyAllToThread, forwardThread } from "../reply";
+import { listAccounts } from "../accounts";
+
+const CDP_PORT = 9333;
+
+describe("reply", () => {
+  let conn: SuperhumanConnection | null = null;
+  let testThreadId: string | null = null;
+
+  beforeAll(async () => {
+    conn = await connectToSuperhuman(CDP_PORT);
+    if (!conn) {
+      throw new Error(
+        "Could not connect to Superhuman. Make sure it is running with --remote-debugging-port=9333"
+      );
+    }
+
+    // Get a thread ID to test with
+    const threads = await listInbox(conn, { limit: 1 });
+    if (threads.length > 0 && threads[0]) {
+      testThreadId = threads[0].id;
+    }
+  });
+
+  afterAll(async () => {
+    if (conn) {
+      // Clean up: close any open compose windows
+      await closeCompose(conn);
+      await disconnect(conn);
+    }
+  });
+
+  test("test_reply_creates_draft_with_correct_recipients", async () => {
+    if (!conn) throw new Error("No connection");
+    if (!testThreadId) throw new Error("No test thread available");
+
+    // Get the original thread to know expected recipients
+    const messages = await readThread(conn, testThreadId);
+    expect(messages.length).toBeGreaterThan(0);
+
+    const lastMessage = messages[messages.length - 1];
+    if (!lastMessage) throw new Error("No messages in thread");
+    const originalSender = lastMessage.from.email;
+    const originalSubject = lastMessage.subject;
+
+    // Reply to the thread
+    const replyBody = "This is a test reply message.";
+    const result = await replyToThread(conn, testThreadId, replyBody, false);
+
+    expect(result.success).toBe(true);
+
+    // Verify draft state
+    const draftState = await getDraftState(conn);
+    expect(draftState).not.toBeNull();
+
+    // To field should contain the original sender
+    expect(draftState!.to).toContain(originalSender);
+
+    // Subject should have "Re:" prefix (avoiding duplicate "Re: Re:")
+    const expectedSubject = originalSubject.startsWith("Re:")
+      ? originalSubject
+      : `Re: ${originalSubject}`;
+    expect(draftState!.subject).toBe(expectedSubject);
+
+    // Body should include our reply text and a blockquote
+    expect(draftState!.body).toContain(replyBody);
+    expect(draftState!.body).toContain("<blockquote");
+  });
+
+  test("reply subject avoids duplicate Re: prefix", async () => {
+    if (!conn) throw new Error("No connection");
+    if (!testThreadId) throw new Error("No test thread available");
+
+    // Get thread messages
+    const messages = await readThread(conn, testThreadId);
+    expect(messages.length).toBeGreaterThan(0);
+
+    const lastMessage = messages[messages.length - 1];
+    if (!lastMessage) throw new Error("No messages in thread");
+    const originalSubject = lastMessage.subject;
+
+    // Reply to the thread
+    const result = await replyToThread(conn, testThreadId, "Test reply", false);
+    expect(result.success).toBe(true);
+
+    const draftState = await getDraftState(conn);
+    expect(draftState).not.toBeNull();
+
+    // Should not have "Re: Re:" pattern
+    expect(draftState!.subject).not.toMatch(/^Re:\s*Re:/i);
+
+    // Should have exactly one "Re:" prefix (if not already present)
+    if (!originalSubject.startsWith("Re:")) {
+      expect(draftState!.subject).toBe(`Re: ${originalSubject}`);
+    } else {
+      expect(draftState!.subject).toBe(originalSubject);
+    }
+  });
+
+  test("reply body includes quoted original message", async () => {
+    if (!conn) throw new Error("No connection");
+    if (!testThreadId) throw new Error("No test thread available");
+
+    const messages = await readThread(conn, testThreadId);
+    expect(messages.length).toBeGreaterThan(0);
+
+    const lastMessage = messages[messages.length - 1];
+    if (!lastMessage) throw new Error("No messages in thread");
+
+    const replyBody = "My reply content here.";
+    const result = await replyToThread(conn, testThreadId, replyBody, false);
+    expect(result.success).toBe(true);
+
+    const draftState = await getDraftState(conn);
+    expect(draftState).not.toBeNull();
+
+    // Body should have the reply content
+    expect(draftState!.body).toContain(replyBody);
+
+    // Body should have a blockquote with attribution
+    expect(draftState!.body).toContain("<blockquote");
+    expect(draftState!.body).toContain("wrote:");
+
+    // Blockquote should include original sender info
+    const senderName = lastMessage.from.name || lastMessage.from.email;
+    expect(draftState!.body).toContain(senderName);
+  });
+
+  test("test_reply_all_includes_all_recipients", async () => {
+    if (!conn) throw new Error("No connection");
+    if (!testThreadId) throw new Error("No test thread available");
+
+    // Get the original thread to know expected recipients
+    const messages = await readThread(conn, testThreadId);
+    expect(messages.length).toBeGreaterThan(0);
+
+    const lastMessage = messages[messages.length - 1];
+    if (!lastMessage) throw new Error("No messages in thread");
+
+    // Get current account to verify self is excluded from Cc
+    const accounts = await listAccounts(conn);
+    const currentAccount = accounts.find((a) => a.isCurrent);
+    if (!currentAccount) throw new Error("No current account found");
+    const currentEmail = currentAccount.email;
+
+    // Reply-all to the thread
+    const replyBody = "This is a test reply-all message.";
+    const result = await replyAllToThread(conn, testThreadId, replyBody, false);
+
+    expect(result.success).toBe(true);
+
+    // Verify draft state
+    const draftState = await getDraftState(conn);
+    expect(draftState).not.toBeNull();
+
+    // To field should contain the original sender
+    expect(draftState!.to).toContain(lastMessage.from.email);
+
+    // Subject should have "Re:" prefix
+    const expectedSubject = lastMessage.subject.startsWith("Re:")
+      ? lastMessage.subject
+      : `Re: ${lastMessage.subject}`;
+    expect(draftState!.subject).toBe(expectedSubject);
+
+    // Body should include our reply text and a blockquote
+    expect(draftState!.body).toContain(replyBody);
+    expect(draftState!.body).toContain("<blockquote");
+
+    // Self (current account) should NOT be in Cc
+    expect(draftState!.cc).not.toContain(currentEmail);
+
+    // Cc should contain other recipients from original To/Cc (excluding self and original sender)
+    const expectedCcRecipients = [
+      ...lastMessage.to.map((r) => r.email),
+      ...lastMessage.cc.map((r) => r.email),
+    ].filter(
+      (email) =>
+        email !== currentEmail && // Exclude self
+        email !== lastMessage.from.email && // Exclude original sender (they're in To)
+        email.length > 0 // Exclude empty emails
+    );
+
+    // Each expected Cc recipient should be in the draft Cc
+    for (const expectedEmail of expectedCcRecipients) {
+      expect(draftState!.cc).toContain(expectedEmail);
+    }
+  });
+
+  test("test_forward_creates_draft_with_forward_header", async () => {
+    if (!conn) throw new Error("No connection");
+    if (!testThreadId) throw new Error("No test thread available");
+
+    // Get the original thread to know expected metadata
+    const messages = await readThread(conn, testThreadId);
+    expect(messages.length).toBeGreaterThan(0);
+
+    const lastMessage = messages[messages.length - 1];
+    if (!lastMessage) throw new Error("No messages in thread");
+
+    // Forward the thread
+    const forwardBody = "Please see the forwarded message below.";
+    const forwardToEmail = "forward-recipient@example.com";
+    const result = await forwardThread(
+      conn,
+      testThreadId,
+      forwardToEmail,
+      forwardBody,
+      false
+    );
+
+    expect(result.success).toBe(true);
+
+    // Verify draft state
+    const draftState = await getDraftState(conn);
+    expect(draftState).not.toBeNull();
+
+    // To field should contain the forward recipient
+    expect(draftState!.to).toContain(forwardToEmail);
+
+    // Subject should have "Fwd:" prefix
+    const expectedSubject = lastMessage.subject.startsWith("Fwd:")
+      ? lastMessage.subject
+      : `Fwd: ${lastMessage.subject}`;
+    expect(draftState!.subject).toBe(expectedSubject);
+
+    // Body should include our forward text
+    expect(draftState!.body).toContain(forwardBody);
+
+    // Body should include forward header with metadata
+    expect(draftState!.body).toContain("---------- Forwarded message ---------");
+    expect(draftState!.body).toContain("From:");
+    expect(draftState!.body).toContain("Date:");
+    expect(draftState!.body).toContain("Subject:");
+    expect(draftState!.body).toContain("To:");
+
+    // Forward header should contain actual message metadata
+    expect(draftState!.body).toContain(lastMessage.from.email);
+    expect(draftState!.body).toContain(lastMessage.subject);
+  });
+});

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -19,6 +19,33 @@ export interface SwitchResult {
 /**
  * List all linked accounts in Superhuman
  */
+/**
+ * Get the current account's email address
+ */
+export async function getCurrentAccount(
+  conn: SuperhumanConnection
+): Promise<string | null> {
+  const { Runtime } = conn;
+
+  const result = await Runtime.evaluate({
+    expression: `
+      (() => {
+        try {
+          return window.GoogleAccount?.emailAddress || null;
+        } catch (e) {
+          return null;
+        }
+      })()
+    `,
+    returnByValue: true,
+  });
+
+  return result.result.value as string | null;
+}
+
+/**
+ * List all linked accounts in Superhuman
+ */
 export async function listAccounts(
   conn: SuperhumanConnection
 ): Promise<Account[]> {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -8,9 +8,9 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
   DraftSchema, SendSchema, SearchSchema, InboxSchema, ReadSchema,
-  AccountsSchema, SwitchAccountSchema,
+  AccountsSchema, SwitchAccountSchema, ReplySchema, ReplyAllSchema, ForwardSchema,
   draftHandler, sendHandler, searchHandler, inboxHandler, readHandler,
-  accountsHandler, switchAccountHandler
+  accountsHandler, switchAccountHandler, replyHandler, replyAllHandler, forwardHandler
 } from "./tools";
 
 function createMcpServer(): McpServer {
@@ -80,6 +80,33 @@ function createMcpServer(): McpServer {
       inputSchema: SwitchAccountSchema,
     },
     switchAccountHandler
+  );
+
+  server.registerTool(
+    "superhuman_reply",
+    {
+      description: "Reply to an email thread. Creates a draft by default, or sends immediately with send=true. The reply is addressed to the sender of the last message in the thread.",
+      inputSchema: ReplySchema,
+    },
+    replyHandler
+  );
+
+  server.registerTool(
+    "superhuman_reply_all",
+    {
+      description: "Reply-all to an email thread. Creates a draft by default, or sends immediately with send=true. The reply is addressed to all recipients of the last message (excluding yourself).",
+      inputSchema: ReplyAllSchema,
+    },
+    replyAllHandler
+  );
+
+  server.registerTool(
+    "superhuman_forward",
+    {
+      description: "Forward an email thread to a new recipient. Creates a draft by default, or sends immediately with send=true. Includes the original message with forwarding headers.",
+      inputSchema: ForwardSchema,
+    },
+    forwardHandler
   );
 
   return server;

--- a/src/reply.ts
+++ b/src/reply.ts
@@ -1,0 +1,343 @@
+/**
+ * Reply Module
+ *
+ * Functions for replying to email threads via Superhuman's internal APIs.
+ */
+
+import type { SuperhumanConnection } from "./superhuman-api";
+import {
+  openCompose,
+  addRecipient,
+  addCcRecipient,
+  setSubject,
+  setBody,
+  saveDraft,
+  sendDraft,
+  textToHtml,
+} from "./superhuman-api";
+import { readThread, type ThreadMessage } from "./read";
+import { getCurrentAccount } from "./accounts";
+
+export interface ReplyResult {
+  success: boolean;
+  draftId?: string;
+}
+
+/**
+ * Format the attribution line for quoted reply
+ */
+function formatAttribution(message: ThreadMessage): string {
+  const senderName = message.from.name || message.from.email;
+  const date = message.date || "Unknown date";
+  return `On ${date}, ${senderName} wrote:`;
+}
+
+/**
+ * Create HTML blockquote for the original message
+ */
+function createQuotedMessage(message: ThreadMessage): string {
+  const attribution = formatAttribution(message);
+  const originalContent = message.snippet || "";
+
+  return `<blockquote style="margin:0 0 0 .8ex;border-left:1px #ccc solid;padding-left:1ex;">
+  <p>${attribution}</p>
+  <p>${originalContent}</p>
+</blockquote>`;
+}
+
+/**
+ * Strip existing "Re:" prefix from subject to avoid "Re: Re:"
+ */
+function stripRePrefix(subject: string): string {
+  // Match "Re:" at the start, case-insensitive, with optional whitespace
+  return subject.replace(/^Re:\s*/i, "");
+}
+
+/**
+ * Strip existing "Fwd:" prefix from subject to avoid "Fwd: Fwd:"
+ */
+function stripFwdPrefix(subject: string): string {
+  // Match "Fwd:" at the start, case-insensitive, with optional whitespace
+  return subject.replace(/^Fwd:\s*/i, "");
+}
+
+/**
+ * Format forward subject with single "Fwd:" prefix
+ */
+function formatForwardSubject(originalSubject: string): string {
+  const stripped = stripFwdPrefix(originalSubject);
+  return `Fwd: ${stripped}`;
+}
+
+/**
+ * Format recipient list as a display string
+ */
+function formatRecipientList(
+  recipients: Array<{ email: string; name: string }>
+): string {
+  return recipients
+    .map((r) => (r.name ? `${r.name} <${r.email}>` : r.email))
+    .join(", ");
+}
+
+/**
+ * Create the forward header with message metadata
+ */
+function createForwardHeader(message: ThreadMessage): string {
+  const senderDisplay = message.from.name
+    ? `${message.from.name} <${message.from.email}>`
+    : message.from.email;
+  const recipientDisplay = formatRecipientList(message.to);
+
+  return `---------- Forwarded message ---------
+From: ${senderDisplay}
+Date: ${message.date}
+Subject: ${message.subject}
+To: ${recipientDisplay}`;
+}
+
+/**
+ * Format reply subject with single "Re:" prefix
+ */
+function formatReplySubject(originalSubject: string): string {
+  const stripped = stripRePrefix(originalSubject);
+  return `Re: ${stripped}`;
+}
+
+/**
+ * Reply to a thread
+ *
+ * @param conn - The Superhuman connection
+ * @param threadId - The thread ID to reply to
+ * @param body - The reply body text
+ * @param send - If true, send immediately; if false, save as draft
+ * @returns Result with success status and optional draft ID
+ */
+export async function replyToThread(
+  conn: SuperhumanConnection,
+  threadId: string,
+  body: string,
+  send: boolean = false
+): Promise<ReplyResult> {
+  // Get thread messages
+  const messages = await readThread(conn, threadId);
+  if (messages.length === 0) {
+    return { success: false };
+  }
+
+  // Get the last message to reply to
+  const lastMessage = messages[messages.length - 1];
+  if (!lastMessage) {
+    return { success: false };
+  }
+
+  // Open compose form
+  const draftKey = await openCompose(conn);
+  if (!draftKey) {
+    return { success: false };
+  }
+
+  // Set recipient to original sender
+  const recipientAdded = await addRecipient(
+    conn,
+    lastMessage.from.email,
+    lastMessage.from.name
+  );
+  if (!recipientAdded) {
+    return { success: false };
+  }
+
+  // Set subject with "Re:" prefix (avoiding duplicate)
+  const replySubject = formatReplySubject(lastMessage.subject);
+  const subjectSet = await setSubject(conn, replySubject);
+  if (!subjectSet) {
+    return { success: false };
+  }
+
+  // Create the reply body with quoted original message
+  const quotedMessage = createQuotedMessage(lastMessage);
+  const bodyHtml = textToHtml(body);
+  const fullBody = `${bodyHtml}\n${quotedMessage}`;
+
+  const bodySet = await setBody(conn, fullBody);
+  if (!bodySet) {
+    return { success: false };
+  }
+
+  // Save or send the draft
+  if (send) {
+    const sent = await sendDraft(conn);
+    return { success: sent };
+  } else {
+    const saved = await saveDraft(conn);
+    return { success: saved, draftId: draftKey };
+  }
+}
+
+/**
+ * Reply-all to a thread
+ *
+ * Same as replyToThread, but also adds all original To/Cc recipients
+ * to the Cc field (excluding self).
+ *
+ * @param conn - The Superhuman connection
+ * @param threadId - The thread ID to reply to
+ * @param body - The reply body text
+ * @param send - If true, send immediately; if false, save as draft
+ * @returns Result with success status and optional draft ID
+ */
+export async function replyAllToThread(
+  conn: SuperhumanConnection,
+  threadId: string,
+  body: string,
+  send: boolean = false
+): Promise<ReplyResult> {
+  // Get current account to exclude self from Cc
+  const currentEmail = await getCurrentAccount(conn);
+
+  // Get thread messages
+  const messages = await readThread(conn, threadId);
+  if (messages.length === 0) {
+    return { success: false };
+  }
+
+  // Get the last message to reply to
+  const lastMessage = messages[messages.length - 1];
+  if (!lastMessage) {
+    return { success: false };
+  }
+
+  // Open compose form
+  const draftKey = await openCompose(conn);
+  if (!draftKey) {
+    return { success: false };
+  }
+
+  // Set recipient to original sender
+  const recipientAdded = await addRecipient(
+    conn,
+    lastMessage.from.email,
+    lastMessage.from.name
+  );
+  if (!recipientAdded) {
+    return { success: false };
+  }
+
+  // Add all original To/Cc recipients to Cc (excluding self and original sender)
+  const allOriginalRecipients = [
+    ...lastMessage.to.map((r) => ({ email: r.email, name: r.name })),
+    ...lastMessage.cc.map((r) => ({ email: r.email, name: r.name })),
+  ];
+
+  // Filter out self and original sender
+  const ccRecipients = allOriginalRecipients.filter(
+    (r) =>
+      r.email.length > 0 &&
+      r.email !== currentEmail &&
+      r.email !== lastMessage.from.email
+  );
+
+  // Add each Cc recipient
+  for (const recipient of ccRecipients) {
+    await addCcRecipient(conn, recipient.email, recipient.name);
+  }
+
+  // Set subject with "Re:" prefix (avoiding duplicate)
+  const replySubject = formatReplySubject(lastMessage.subject);
+  const subjectSet = await setSubject(conn, replySubject);
+  if (!subjectSet) {
+    return { success: false };
+  }
+
+  // Create the reply body with quoted original message
+  const quotedMessage = createQuotedMessage(lastMessage);
+  const bodyHtml = textToHtml(body);
+  const fullBody = `${bodyHtml}\n${quotedMessage}`;
+
+  const bodySet = await setBody(conn, fullBody);
+  if (!bodySet) {
+    return { success: false };
+  }
+
+  // Save or send the draft
+  if (send) {
+    const sent = await sendDraft(conn);
+    return { success: sent };
+  } else {
+    const saved = await saveDraft(conn);
+    return { success: saved, draftId: draftKey };
+  }
+}
+
+/**
+ * Forward a thread
+ *
+ * Creates a new email with the forwarded message content and metadata.
+ *
+ * @param conn - The Superhuman connection
+ * @param threadId - The thread ID to forward
+ * @param toEmail - The email address to forward to
+ * @param body - The message body to include before the forwarded content
+ * @param send - If true, send immediately; if false, save as draft
+ * @returns Result with success status and optional draft ID
+ */
+export async function forwardThread(
+  conn: SuperhumanConnection,
+  threadId: string,
+  toEmail: string,
+  body: string,
+  send: boolean = false
+): Promise<ReplyResult> {
+  // Get thread messages
+  const messages = await readThread(conn, threadId);
+  if (messages.length === 0) {
+    return { success: false };
+  }
+
+  // Get the last message to forward
+  const lastMessage = messages[messages.length - 1];
+  if (!lastMessage) {
+    return { success: false };
+  }
+
+  // Open compose form
+  const draftKey = await openCompose(conn);
+  if (!draftKey) {
+    return { success: false };
+  }
+
+  // Set recipient to the forward target
+  const recipientAdded = await addRecipient(conn, toEmail);
+  if (!recipientAdded) {
+    return { success: false };
+  }
+
+  // Set subject with "Fwd:" prefix (avoiding duplicate)
+  const forwardSubject = formatForwardSubject(lastMessage.subject);
+  const subjectSet = await setSubject(conn, forwardSubject);
+  if (!subjectSet) {
+    return { success: false };
+  }
+
+  // Create the forward body with header and original message
+  const forwardHeader = createForwardHeader(lastMessage);
+  const originalContent = lastMessage.snippet || "";
+  const bodyHtml = textToHtml(body);
+  const headerHtml = textToHtml(forwardHeader);
+  const originalHtml = textToHtml(originalContent);
+  const fullBody = `${bodyHtml}\n\n${headerHtml}\n\n${originalHtml}`;
+
+  const bodySet = await setBody(conn, fullBody);
+  if (!bodySet) {
+    return { success: false };
+  }
+
+  // Save or send the draft
+  if (send) {
+    const sent = await sendDraft(conn);
+    return { success: sent };
+  } else {
+    const saved = await saveDraft(conn);
+    return { success: saved, draftId: draftKey };
+  }
+}

--- a/src/superhuman-api.ts
+++ b/src/superhuman-api.ts
@@ -200,6 +200,12 @@ export async function addRecipient(
       const draft = ctrl?.state?.draft;
       if (!draft?.from?.constructor) return false;
 
+      const existingTo = draft.to || [];
+
+      // Check if email already exists in To field
+      const alreadyExists = existingTo.some(r => r.email === ${JSON.stringify(email)});
+      if (alreadyExists) return true; // Already there, success
+
       const Recipient = draft.from.constructor;
       const newRecipient = new Recipient({
         email: ${JSON.stringify(email)},
@@ -207,8 +213,41 @@ export async function addRecipient(
         raw: ${JSON.stringify(name ? `${name} <${email}>` : email)},
       });
 
-      const existingTo = draft.to || [];
       ctrl._updateDraft({ to: [...existingTo, newRecipient] });
+      return true;
+    `
+  );
+  return result === true;
+}
+
+/**
+ * Add a recipient to the Cc field
+ */
+export async function addCcRecipient(
+  conn: SuperhumanConnection,
+  email: string,
+  name?: string
+): Promise<boolean> {
+  const result = await withDraftController<boolean>(
+    conn,
+    `
+      const draft = ctrl?.state?.draft;
+      if (!draft?.from?.constructor) return false;
+
+      const existingCc = draft.cc || [];
+
+      // Check if email already exists in Cc field
+      const alreadyExists = existingCc.some(r => r.email === ${JSON.stringify(email)});
+      if (alreadyExists) return true; // Already there, success
+
+      const Recipient = draft.from.constructor;
+      const newRecipient = new Recipient({
+        email: ${JSON.stringify(email)},
+        name: ${JSON.stringify(name || "")},
+        raw: ${JSON.stringify(name ? `${name} <${email}>` : email)},
+      });
+
+      ctrl._updateDraft({ cc: [...existingCc, newRecipient] });
       return true;
     `
   );


### PR DESCRIPTION
## Summary

- Add `reply`, `reply-all`, and `forward` CLI commands
- Add `superhuman_reply`, `superhuman_reply_all`, `superhuman_forward` MCP tools
- Support `--body`, `--send`, and `--to` flags

## Changes

### New Files
- `src/reply.ts` - Core reply/forward functions
- `src/__tests__/reply.test.ts` - Tests for reply functionality

### Modified Files
- `src/accounts.ts` - Add `getCurrentAccount()` for reply-all self-exclusion
- `src/superhuman-api.ts` - Add `addCcRecipient()` with duplicate detection
- `src/cli.ts` - Add reply, reply-all, forward commands
- `src/mcp/tools.ts` - Add MCP tool handlers
- `src/mcp/server.ts` - Register new MCP tools

## Test plan

- [x] All 24 tests pass
- [x] Verified reply creates draft with correct recipient (no duplicates)
- [x] Verified subject has "Re:" prefix
- [x] Verified body includes quoted original message

🤖 Generated with [Claude Code](https://claude.com/claude-code)