### PR TITLE
feat: add reply/forward via cached credentials + Superhuman native send

### DIFF
--- a/src/__tests__/forward-account.test.ts
+++ b/src/__tests__/forward-account.test.ts
@@ -1,0 +1,125 @@
+// src/__tests__/forward-account.test.ts
+// Tests for the forward command with --account flag (fast path)
+import { test, expect, describe } from "bun:test";
+
+describe("forward command with --account flag", () => {
+  describe("command registration", () => {
+    test("forward command appears in help", async () => {
+      const proc = Bun.spawn(["bun", "run", "src/cli.ts", "--help"], {
+        cwd: "/Users/vwh7mb/projects/superhuman-cli/.worktrees/reply-forward-cached",
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const stdout = await new Response(proc.stdout).text();
+      const exitCode = await proc.exited;
+
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("forward");
+    });
+  });
+
+  describe("--account flag handling", () => {
+    test("forward with --account requires thread-id argument", async () => {
+      // Run forward without a thread-id - should show usage error
+      const proc = Bun.spawn(
+        ["bun", "run", "src/cli.ts", "forward", "--account=test@example.com", "--to=recipient@example.com", "--body=FYI"],
+        {
+          cwd: "/Users/vwh7mb/projects/superhuman-cli/.worktrees/reply-forward-cached",
+          stdout: "pipe",
+          stderr: "pipe",
+        }
+      );
+      const stderr = await new Response(proc.stderr).text();
+      const stdout = await new Response(proc.stdout).text();
+      const exitCode = await proc.exited;
+      const output = stdout + stderr;
+
+      // Should error because no thread-id provided
+      expect(output).toMatch(/thread.*id|required/i);
+      expect(exitCode).not.toBe(0);
+    });
+
+    test("forward with --account requires --to recipient", async () => {
+      // Run forward with --account but no --to
+      const proc = Bun.spawn(
+        ["bun", "run", "src/cli.ts", "forward", "test-thread-123", "--account=test@example.com", "--body=FYI"],
+        {
+          cwd: "/Users/vwh7mb/projects/superhuman-cli/.worktrees/reply-forward-cached",
+          stdout: "pipe",
+          stderr: "pipe",
+        }
+      );
+      const stderr = await new Response(proc.stderr).text();
+      const stdout = await new Response(proc.stdout).text();
+      const exitCode = await proc.exited;
+      const output = stdout + stderr;
+
+      // Should error because no --to provided
+      expect(output).toMatch(/recipient|--to/i);
+      expect(exitCode).not.toBe(0);
+    });
+
+    test("forward with --account and no cached credentials falls back gracefully", async () => {
+      // Run forward with --account for an account that doesn't have cached credentials
+      // Should warn about no cached credentials and fall back to CDP path
+      // (which will fail because no Superhuman is running, but that's expected)
+      const proc = Bun.spawn(
+        ["bun", "run", "src/cli.ts", "forward", "test-thread-123", "--account=nonexistent@example.com", "--to=recipient@example.com", "--body=FYI"],
+        {
+          cwd: "/Users/vwh7mb/projects/superhuman-cli/.worktrees/reply-forward-cached",
+          stdout: "pipe",
+          stderr: "pipe",
+        }
+      );
+      const stderr = await new Response(proc.stderr).text();
+      const stdout = await new Response(proc.stdout).text();
+      const exitCode = await proc.exited;
+      const output = stdout + stderr;
+
+      // Should warn about no cached credentials and fall back to CDP
+      expect(output).toMatch(/no cached credentials|falling back/i);
+    });
+
+    test("forward with --account uses Superhuman draft API (without --send)", async () => {
+      // This test verifies the code path exists - in practice needs mocking for full coverage
+      // For now, verify it accepts the --account flag in the context of forward
+      const proc = Bun.spawn(
+        ["bun", "run", "src/cli.ts", "forward", "thread123", "--account=test@example.com", "--to=recipient@example.com", "--body=FYI"],
+        {
+          cwd: "/Users/vwh7mb/projects/superhuman-cli/.worktrees/reply-forward-cached",
+          stdout: "pipe",
+          stderr: "pipe",
+        }
+      );
+      const stderr = await new Response(proc.stderr).text();
+      const stdout = await new Response(proc.stdout).text();
+      const exitCode = await proc.exited;
+      const output = stdout + stderr;
+
+      // Should show it's trying to use cached credentials path (even if it fails due to no credentials)
+      // The important thing is --account is recognized and handled
+      expect(output).not.toMatch(/unknown.*option.*account|unrecognized.*account/i);
+    });
+
+    test("forward with --account and --send attempts direct send", async () => {
+      // This test verifies the --send + --account combo is handled
+      const proc = Bun.spawn(
+        ["bun", "run", "src/cli.ts", "forward", "thread123", "--account=test@example.com", "--to=recipient@example.com", "--body=FYI", "--send"],
+        {
+          cwd: "/Users/vwh7mb/projects/superhuman-cli/.worktrees/reply-forward-cached",
+          stdout: "pipe",
+          stderr: "pipe",
+        }
+      );
+      const stderr = await new Response(proc.stderr).text();
+      const stdout = await new Response(proc.stdout).text();
+      const exitCode = await proc.exited;
+      const output = stdout + stderr;
+
+      // Should not crash with unknown option error
+      expect(output).not.toMatch(/unknown.*option.*account|unrecognized.*account/i);
+      // Should either attempt the direct send path or fall back
+      expect(output).toMatch(/no cached credentials|falling back|not running|connection|credentials|forward/i);
+    });
+  });
+});

--- a/src/__tests__/reply-account.test.ts
+++ b/src/__tests__/reply-account.test.ts
@@ -1,0 +1,105 @@
+// src/__tests__/reply-account.test.ts
+// Tests for the reply command with --account flag (fast path)
+import { test, expect, describe } from "bun:test";
+
+describe("reply command with --account flag", () => {
+  describe("command registration", () => {
+    test("reply command appears in help", async () => {
+      const proc = Bun.spawn(["bun", "run", "src/cli.ts", "--help"], {
+        cwd: "/Users/vwh7mb/projects/superhuman-cli/.worktrees/reply-forward-cached",
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const stdout = await new Response(proc.stdout).text();
+      const exitCode = await proc.exited;
+
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("reply");
+    });
+  });
+
+  describe("--account flag handling", () => {
+    test("reply with --account requires thread-id argument", async () => {
+      // Run reply without a thread-id - should show usage error
+      const proc = Bun.spawn(
+        ["bun", "run", "src/cli.ts", "reply", "--account=test@example.com", "--body=Test reply"],
+        {
+          cwd: "/Users/vwh7mb/projects/superhuman-cli/.worktrees/reply-forward-cached",
+          stdout: "pipe",
+          stderr: "pipe",
+        }
+      );
+      const stderr = await new Response(proc.stderr).text();
+      const stdout = await new Response(proc.stdout).text();
+      const exitCode = await proc.exited;
+      const output = stdout + stderr;
+
+      // Should error because no thread-id provided
+      expect(output).toMatch(/thread.*id|required/i);
+      expect(exitCode).not.toBe(0);
+    });
+
+    test("reply with --account and no cached credentials falls back gracefully", async () => {
+      // Run reply with --account for an account that doesn't have cached credentials
+      // Should warn about no cached credentials and fall back to CDP path
+      // (which will fail because no Superhuman is running, but that's expected)
+      const proc = Bun.spawn(
+        ["bun", "run", "src/cli.ts", "reply", "test-thread-123", "--account=nonexistent@example.com", "--body=Test reply"],
+        {
+          cwd: "/Users/vwh7mb/projects/superhuman-cli/.worktrees/reply-forward-cached",
+          stdout: "pipe",
+          stderr: "pipe",
+        }
+      );
+      const stderr = await new Response(proc.stderr).text();
+      const stdout = await new Response(proc.stdout).text();
+      const exitCode = await proc.exited;
+      const output = stdout + stderr;
+
+      // Should warn about no cached credentials and fall back to CDP
+      expect(output).toMatch(/no cached credentials|falling back/i);
+    });
+
+    test("reply with --account uses Superhuman draft API (without --send)", async () => {
+      // This test verifies the code path exists - in practice needs mocking for full coverage
+      // For now, verify it accepts the --account flag in the context of reply
+      const proc = Bun.spawn(
+        ["bun", "run", "src/cli.ts", "reply", "thread123", "--account=test@example.com", "--body=Reply text"],
+        {
+          cwd: "/Users/vwh7mb/projects/superhuman-cli/.worktrees/reply-forward-cached",
+          stdout: "pipe",
+          stderr: "pipe",
+        }
+      );
+      const stderr = await new Response(proc.stderr).text();
+      const stdout = await new Response(proc.stdout).text();
+      const exitCode = await proc.exited;
+      const output = stdout + stderr;
+
+      // Should show it's trying to use cached credentials path (even if it fails due to no credentials)
+      // The important thing is --account is recognized and handled
+      expect(output).not.toMatch(/unknown.*option.*account|unrecognized.*account/i);
+    });
+
+    test("reply with --account and --send attempts direct send", async () => {
+      // This test verifies the --send + --account combo is handled
+      const proc = Bun.spawn(
+        ["bun", "run", "src/cli.ts", "reply", "thread123", "--account=test@example.com", "--body=Reply text", "--send"],
+        {
+          cwd: "/Users/vwh7mb/projects/superhuman-cli/.worktrees/reply-forward-cached",
+          stdout: "pipe",
+          stderr: "pipe",
+        }
+      );
+      const stderr = await new Response(proc.stderr).text();
+      const stdout = await new Response(proc.stdout).text();
+      const exitCode = await proc.exited;
+      const output = stdout + stderr;
+
+      // Should not crash with unknown option error
+      expect(output).not.toMatch(/unknown.*option.*account|unrecognized.*account/i);
+      // Should either attempt the direct send path or fall back
+      expect(output).toMatch(/no cached credentials|falling back|not running|connection|credentials|reply/i);
+    });
+  });
+});

--- a/src/__tests__/reply-all-account.test.ts
+++ b/src/__tests__/reply-all-account.test.ts
@@ -1,0 +1,123 @@
+// src/__tests__/reply-all-account.test.ts
+// Tests for the reply-all command with --account flag (fast path)
+import { test, expect, describe } from "bun:test";
+
+describe("reply-all command with --account flag", () => {
+  describe("command registration", () => {
+    test("reply-all command appears in help", async () => {
+      const proc = Bun.spawn(["bun", "run", "src/cli.ts", "--help"], {
+        cwd: "/Users/vwh7mb/projects/superhuman-cli/.worktrees/reply-forward-cached",
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const stdout = await new Response(proc.stdout).text();
+      const exitCode = await proc.exited;
+
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("reply-all");
+    });
+  });
+
+  describe("--account flag handling", () => {
+    test("reply-all with --account requires thread-id argument", async () => {
+      // Run reply-all without a thread-id - should show usage error
+      const proc = Bun.spawn(
+        ["bun", "run", "src/cli.ts", "reply-all", "--account=test@example.com", "--body=Test reply-all"],
+        {
+          cwd: "/Users/vwh7mb/projects/superhuman-cli/.worktrees/reply-forward-cached",
+          stdout: "pipe",
+          stderr: "pipe",
+        }
+      );
+      const stderr = await new Response(proc.stderr).text();
+      const stdout = await new Response(proc.stdout).text();
+      const exitCode = await proc.exited;
+      const output = stdout + stderr;
+
+      // Should error because no thread-id provided
+      expect(output).toMatch(/thread.*id|required/i);
+      expect(exitCode).not.toBe(0);
+    });
+
+    test("reply-all with --account and no cached credentials falls back gracefully", async () => {
+      // Run reply-all with --account for an account that doesn't have cached credentials
+      // Should warn about no cached credentials and fall back to CDP path
+      // (which will fail because no Superhuman is running, but that's expected)
+      const proc = Bun.spawn(
+        ["bun", "run", "src/cli.ts", "reply-all", "test-thread-123", "--account=nonexistent@example.com", "--body=Test reply-all"],
+        {
+          cwd: "/Users/vwh7mb/projects/superhuman-cli/.worktrees/reply-forward-cached",
+          stdout: "pipe",
+          stderr: "pipe",
+        }
+      );
+      const stderr = await new Response(proc.stderr).text();
+      const stdout = await new Response(proc.stdout).text();
+      const exitCode = await proc.exited;
+      const output = stdout + stderr;
+
+      // Should warn about no cached credentials and fall back to CDP
+      expect(output).toMatch(/no cached credentials|falling back/i);
+    });
+
+    test("reply-all with --account uses Superhuman draft API (without --send)", async () => {
+      // This test verifies the code path exists - in practice needs mocking for full coverage
+      // For now, verify it accepts the --account flag in the context of reply-all
+      const proc = Bun.spawn(
+        ["bun", "run", "src/cli.ts", "reply-all", "thread123", "--account=test@example.com", "--body=Reply-all text"],
+        {
+          cwd: "/Users/vwh7mb/projects/superhuman-cli/.worktrees/reply-forward-cached",
+          stdout: "pipe",
+          stderr: "pipe",
+        }
+      );
+      const stderr = await new Response(proc.stderr).text();
+      const stdout = await new Response(proc.stdout).text();
+      const exitCode = await proc.exited;
+      const output = stdout + stderr;
+
+      // Should show it's trying to use cached credentials path (even if it fails due to no credentials)
+      // The important thing is --account is recognized and handled
+      expect(output).not.toMatch(/unknown.*option.*account|unrecognized.*account/i);
+    });
+
+    test("reply-all with --account and --send attempts direct send", async () => {
+      // This test verifies the --send + --account combo is handled
+      const proc = Bun.spawn(
+        ["bun", "run", "src/cli.ts", "reply-all", "thread123", "--account=test@example.com", "--body=Reply-all text", "--send"],
+        {
+          cwd: "/Users/vwh7mb/projects/superhuman-cli/.worktrees/reply-forward-cached",
+          stdout: "pipe",
+          stderr: "pipe",
+        }
+      );
+      const stderr = await new Response(proc.stderr).text();
+      const stdout = await new Response(proc.stdout).text();
+      const exitCode = await proc.exited;
+      const output = stdout + stderr;
+
+      // Should not crash with unknown option error
+      expect(output).not.toMatch(/unknown.*option.*account|unrecognized.*account/i);
+      // Should either attempt the direct send path or fall back
+      expect(output).toMatch(/no cached credentials|falling back|not running|connection|credentials|reply-all/i);
+    });
+
+    test("reply-all usage string includes --account flag", async () => {
+      // Trigger the usage message by providing reply-all without thread-id
+      const proc = Bun.spawn(
+        ["bun", "run", "src/cli.ts", "reply-all"],
+        {
+          cwd: "/Users/vwh7mb/projects/superhuman-cli/.worktrees/reply-forward-cached",
+          stdout: "pipe",
+          stderr: "pipe",
+        }
+      );
+      const stderr = await new Response(proc.stderr).text();
+      const stdout = await new Response(proc.stdout).text();
+      const output = stdout + stderr;
+
+      // Usage message should mention --account flag
+      expect(output).toMatch(/--account/i);
+    });
+  });
+});

--- a/src/__tests__/send-draft-cli.test.ts
+++ b/src/__tests__/send-draft-cli.test.ts
@@ -1,0 +1,156 @@
+// src/__tests__/send-draft-cli.test.ts
+// Tests for the send-draft CLI command
+import { test, expect, describe, mock, afterEach, beforeEach } from "bun:test";
+import { $ } from "bun";
+
+describe("send-draft CLI command", () => {
+  describe("command registration", () => {
+    test("send-draft command appears in help", async () => {
+      // Run the CLI with --help and check that send-draft is listed
+      const proc = Bun.spawn(["bun", "run", "src/cli.ts", "--help"], {
+        cwd: "/Users/vwh7mb/projects/superhuman-cli/.worktrees/reply-forward-cached",
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const stdout = await new Response(proc.stdout).text();
+      const exitCode = await proc.exited;
+
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("send-draft");
+    });
+
+    test("send-draft command requires draft-id argument", async () => {
+      // Run send-draft without a draft-id - should show usage error
+      const proc = Bun.spawn(
+        ["bun", "run", "src/cli.ts", "send-draft", "--account=test@example.com", "--to=recipient@example.com", "--subject=Test", "--body=Test body"],
+        {
+          cwd: "/Users/vwh7mb/projects/superhuman-cli/.worktrees/reply-forward-cached",
+          stdout: "pipe",
+          stderr: "pipe",
+        }
+      );
+      const stderr = await new Response(proc.stderr).text();
+      const stdout = await new Response(proc.stdout).text();
+      const exitCode = await proc.exited;
+      const output = stdout + stderr;
+
+      // Should error because no draft-id provided
+      expect(output).toMatch(/draft.*id|required/i);
+    });
+
+    test("send-draft validates draft-id format", async () => {
+      // Run send-draft with an invalid draft ID
+      const proc = Bun.spawn(
+        ["bun", "run", "src/cli.ts", "send-draft", "invalid-id", "--account=test@example.com", "--to=recipient@example.com", "--subject=Test", "--body=Test body"],
+        {
+          cwd: "/Users/vwh7mb/projects/superhuman-cli/.worktrees/reply-forward-cached",
+          stdout: "pipe",
+          stderr: "pipe",
+        }
+      );
+      const stderr = await new Response(proc.stderr).text();
+      const stdout = await new Response(proc.stdout).text();
+      const exitCode = await proc.exited;
+      const output = stdout + stderr;
+
+      // Should error about invalid draft ID format
+      expect(output).toMatch(/invalid.*draft.*id|must.*start.*draft00/i);
+      expect(exitCode).not.toBe(0);
+    });
+
+    test("send-draft requires --account flag", async () => {
+      // Run send-draft without --account flag
+      const proc = Bun.spawn(
+        ["bun", "run", "src/cli.ts", "send-draft", "draft00abcdef123456", "--to=recipient@example.com", "--subject=Test", "--body=Test body"],
+        {
+          cwd: "/Users/vwh7mb/projects/superhuman-cli/.worktrees/reply-forward-cached",
+          stdout: "pipe",
+          stderr: "pipe",
+        }
+      );
+      const stderr = await new Response(proc.stderr).text();
+      const stdout = await new Response(proc.stdout).text();
+      const exitCode = await proc.exited;
+      const output = stdout + stderr;
+
+      // Should error about missing --account flag
+      expect(output).toMatch(/--account.*required|account.*required/i);
+      expect(exitCode).not.toBe(0);
+    });
+
+    test("send-draft requires --to flag", async () => {
+      // Run send-draft without --to flag
+      const proc = Bun.spawn(
+        ["bun", "run", "src/cli.ts", "send-draft", "draft00abcdef123456", "--account=test@example.com", "--subject=Test", "--body=Test body"],
+        {
+          cwd: "/Users/vwh7mb/projects/superhuman-cli/.worktrees/reply-forward-cached",
+          stdout: "pipe",
+          stderr: "pipe",
+        }
+      );
+      const stderr = await new Response(proc.stderr).text();
+      const stdout = await new Response(proc.stdout).text();
+      const exitCode = await proc.exited;
+      const output = stdout + stderr;
+
+      // Should error about missing --to flag
+      expect(output).toMatch(/--to.*required|recipient.*required/i);
+      expect(exitCode).not.toBe(0);
+    });
+
+    test("send-draft requires --subject flag", async () => {
+      // Run send-draft without --subject flag
+      const proc = Bun.spawn(
+        ["bun", "run", "src/cli.ts", "send-draft", "draft00abcdef123456", "--account=test@example.com", "--to=recipient@example.com", "--body=Test body"],
+        {
+          cwd: "/Users/vwh7mb/projects/superhuman-cli/.worktrees/reply-forward-cached",
+          stdout: "pipe",
+          stderr: "pipe",
+        }
+      );
+      const stderr = await new Response(proc.stderr).text();
+      const stdout = await new Response(proc.stdout).text();
+      const exitCode = await proc.exited;
+      const output = stdout + stderr;
+
+      // Should error about missing --subject flag
+      expect(output).toMatch(/--subject.*required|subject.*required/i);
+      expect(exitCode).not.toBe(0);
+    });
+
+    test("send-draft requires --body flag", async () => {
+      // Run send-draft without --body flag
+      const proc = Bun.spawn(
+        ["bun", "run", "src/cli.ts", "send-draft", "draft00abcdef123456", "--account=test@example.com", "--to=recipient@example.com", "--subject=Test"],
+        {
+          cwd: "/Users/vwh7mb/projects/superhuman-cli/.worktrees/reply-forward-cached",
+          stdout: "pipe",
+          stderr: "pipe",
+        }
+      );
+      const stderr = await new Response(proc.stderr).text();
+      const stdout = await new Response(proc.stdout).text();
+      const exitCode = await proc.exited;
+      const output = stdout + stderr;
+
+      // Should error about missing --body flag
+      expect(output).toMatch(/--body.*required|body.*required/i);
+      expect(exitCode).not.toBe(0);
+    });
+
+    test("send-draft shows --thread option in help examples", async () => {
+      // Run the CLI with --help and check that --thread is documented
+      const proc = Bun.spawn(["bun", "run", "src/cli.ts", "--help"], {
+        cwd: "/Users/vwh7mb/projects/superhuman-cli/.worktrees/reply-forward-cached",
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const stdout = await new Response(proc.stdout).text();
+      const exitCode = await proc.exited;
+
+      expect(exitCode).toBe(0);
+      // Check that --thread option is documented in send-draft examples
+      expect(stdout).toMatch(/--thread/);
+    });
+  });
+});

--- a/src/__tests__/send-draft.test.ts
+++ b/src/__tests__/send-draft.test.ts
@@ -1,0 +1,241 @@
+// src/__tests__/send-draft.test.ts
+import { test, expect, describe, afterEach, mock } from "bun:test";
+import {
+  sendDraftSuperhuman,
+  getUserInfoFromCache,
+  type SendDraftOptions,
+} from "../draft-api";
+
+describe("sendDraftSuperhuman", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    // Restore original fetch after each test
+    globalThis.fetch = originalFetch;
+  });
+
+  /**
+   * Helper to create a mock fetch function
+   */
+  function createMockFetch(response: { ok: boolean; status?: number; data?: unknown; text?: string }) {
+    const mockFn = mock(() =>
+      Promise.resolve({
+        ok: response.ok,
+        status: response.status ?? (response.ok ? 200 : 500),
+        json: () => Promise.resolve(response.data ?? {}),
+        text: () => Promise.resolve(response.text ?? ""),
+      } as Response)
+    );
+    // Cast to any to bypass Bun's fetch type requiring preconnect
+    globalThis.fetch = mockFn as unknown as typeof fetch;
+    return mockFn;
+  }
+
+  test("sends to correct endpoint with proper payload structure", async () => {
+    // Arrange
+    const mockSendAt = 1770276316728;
+    const mockFetch = createMockFetch({ ok: true, data: { send_at: mockSendAt } });
+
+    const userInfo = getUserInfoFromCache(
+      "user123",
+      "sender@example.com",
+      "token123",
+      "Test User"
+    );
+
+    const options: SendDraftOptions = {
+      draftId: "draft00abcdef123456",
+      threadId: "draft00abcdef123456",
+      to: [{ email: "recipient@example.com", name: "Recipient Name" }],
+      subject: "Test Subject",
+      htmlBody: "<p>Test body</p>",
+    };
+
+    // Act
+    const result = await sendDraftSuperhuman(userInfo, options);
+
+    // Assert
+    expect(result.success).toBe(true);
+    expect(result.sendAt).toBe(mockSendAt);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    // Verify endpoint
+    const calls = mockFetch.mock.calls;
+    expect(calls.length).toBe(1);
+    const [url, fetchOptions] = calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe("https://mail.superhuman.com/~backend/messages/send");
+    expect(fetchOptions.method).toBe("POST");
+    expect(fetchOptions.headers).toHaveProperty("Authorization", "Bearer token123");
+  });
+
+  test("includes correct outgoing_message structure", async () => {
+    // Arrange
+    const mockFetch = createMockFetch({ ok: true, data: { send_at: 1234567890 } });
+
+    const userInfo = getUserInfoFromCache(
+      "user123",
+      "sender@example.com",
+      "token123",
+      "Test User"
+    );
+
+    const options: SendDraftOptions = {
+      draftId: "draft00abcdef123456",
+      threadId: "draft00abcdef123456",
+      to: [
+        { email: "recipient1@example.com", name: "Recipient One" },
+        { email: "recipient2@example.com" },
+      ],
+      cc: [{ email: "cc@example.com", name: "CC Person" }],
+      bcc: [{ email: "bcc@example.com" }],
+      subject: "Test Subject",
+      htmlBody: "<p>Test body</p>",
+    };
+
+    // Act
+    await sendDraftSuperhuman(userInfo, options);
+
+    // Assert
+    const calls = mockFetch.mock.calls;
+    const [, fetchOptions] = calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(fetchOptions.body as string);
+
+    expect(body.version).toBe(3);
+    expect(body.outgoing_message).toBeDefined();
+    expect(body.outgoing_message.from.email).toBe("sender@example.com");
+    expect(body.outgoing_message.to).toHaveLength(2);
+    expect(body.outgoing_message.to[0]).toEqual({
+      email: "recipient1@example.com",
+      name: "Recipient One",
+    });
+    expect(body.outgoing_message.to[1]).toEqual({
+      email: "recipient2@example.com",
+      name: "",
+    });
+    expect(body.outgoing_message.cc).toHaveLength(1);
+    expect(body.outgoing_message.bcc).toHaveLength(1);
+    expect(body.outgoing_message.subject).toBe("Test Subject");
+    expect(body.outgoing_message.html_body).toBe("<p>Test body</p>");
+    expect(body.outgoing_message.thread_id).toBe("draft00abcdef123456");
+    expect(body.outgoing_message.message_id).toBe("draft00abcdef123456");
+  });
+
+  test("uses default delay of 20 seconds when not specified", async () => {
+    // Arrange
+    const mockFetch = createMockFetch({ ok: true, data: { send_at: 1234567890 } });
+
+    const userInfo = getUserInfoFromCache("user123", "sender@example.com", "token123");
+
+    const options: SendDraftOptions = {
+      draftId: "draft00abcdef123456",
+      threadId: "draft00abcdef123456",
+      to: [{ email: "recipient@example.com" }],
+      subject: "Test",
+      htmlBody: "<p>Body</p>",
+    };
+
+    // Act
+    await sendDraftSuperhuman(userInfo, options);
+
+    // Assert
+    const calls = mockFetch.mock.calls;
+    const [, fetchOptions] = calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(fetchOptions.body as string);
+    expect(body.delay).toBe(20);
+  });
+
+  test("respects custom delay parameter", async () => {
+    // Arrange
+    const mockFetch = createMockFetch({ ok: true, data: { send_at: 1234567890 } });
+
+    const userInfo = getUserInfoFromCache("user123", "sender@example.com", "token123");
+
+    const options: SendDraftOptions = {
+      draftId: "draft00abcdef123456",
+      threadId: "draft00abcdef123456",
+      to: [{ email: "recipient@example.com" }],
+      subject: "Test",
+      htmlBody: "<p>Body</p>",
+      delay: 3600, // 1 hour delay
+    };
+
+    // Act
+    await sendDraftSuperhuman(userInfo, options);
+
+    // Assert
+    const calls = mockFetch.mock.calls;
+    const [, fetchOptions] = calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(fetchOptions.body as string);
+    expect(body.delay).toBe(3600);
+  });
+
+  test("supports immediate send with delay=0", async () => {
+    // Arrange
+    const mockFetch = createMockFetch({ ok: true, data: { send_at: 1234567890 } });
+
+    const userInfo = getUserInfoFromCache("user123", "sender@example.com", "token123");
+
+    const options: SendDraftOptions = {
+      draftId: "draft00abcdef123456",
+      threadId: "draft00abcdef123456",
+      to: [{ email: "recipient@example.com" }],
+      subject: "Test",
+      htmlBody: "<p>Body</p>",
+      delay: 0, // Immediate send
+    };
+
+    // Act
+    await sendDraftSuperhuman(userInfo, options);
+
+    // Assert
+    const calls = mockFetch.mock.calls;
+    const [, fetchOptions] = calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(fetchOptions.body as string);
+    expect(body.delay).toBe(0);
+  });
+
+  test("returns error on API failure", async () => {
+    // Arrange
+    createMockFetch({ ok: false, status: 401, text: "Unauthorized" });
+
+    const userInfo = getUserInfoFromCache("user123", "sender@example.com", "token123");
+
+    const options: SendDraftOptions = {
+      draftId: "draft00abcdef123456",
+      threadId: "draft00abcdef123456",
+      to: [{ email: "recipient@example.com" }],
+      subject: "Test",
+      htmlBody: "<p>Body</p>",
+    };
+
+    // Act
+    const result = await sendDraftSuperhuman(userInfo, options);
+
+    // Assert
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("401");
+  });
+
+  test("handles network errors gracefully", async () => {
+    // Arrange - mock fetch to throw network error
+    const mockFn = mock(() => Promise.reject(new Error("Network error")));
+    globalThis.fetch = mockFn as unknown as typeof fetch;
+
+    const userInfo = getUserInfoFromCache("user123", "sender@example.com", "token123");
+
+    const options: SendDraftOptions = {
+      draftId: "draft00abcdef123456",
+      threadId: "draft00abcdef123456",
+      to: [{ email: "recipient@example.com" }],
+      subject: "Test",
+      htmlBody: "<p>Body</p>",
+    };
+
+    // Act
+    const result = await sendDraftSuperhuman(userInfo, options);
+
+    // Assert
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Network error");
+  });
+});


### PR DESCRIPTION
## Summary

- Add `sendDraftSuperhuman()` to send drafts via `/messages/send` endpoint
- Add `send-draft` CLI command with `--delay` for scheduled send
- Add `--account` fast path to `cmdReply`, `cmdReplyAll`, `cmdForward`
- Reply/forward without `--send` creates Superhuman draft (syncs to all devices)
- Reply/forward with `--send` sends immediately via Gmail/MS Graph
- Add `--thread` option to `send-draft` for reply/forward drafts
- Falls back to CDP path when `--account` not specified

## New Commands

```bash
# Send a Superhuman draft
superhuman send-draft <draft-id> --account=email --to=x --subject=y --body=z
superhuman send-draft <draft-id> --account=email ... --delay=60  # Scheduled send

# Reply with cached credentials (no CDP needed)
superhuman reply <thread> --account=email --body "text"        # Creates draft
superhuman reply <thread> --account=email --body "text" --send # Sends immediately

# Forward with cached credentials
superhuman forward <thread> --account=email --to=x --body "text"
superhuman forward <thread> --account=email --to=x --body "text" --send

# Reply-all also supported
superhuman reply-all <thread> --account=email --body "text"
```

## Test plan

- [x] 68 unit tests pass (`bun test`)
- [ ] Manual: Create reply draft with `--account`, verify in Superhuman UI
- [ ] Manual: Send reply with `--account --send`, verify email delivered
- [ ] Manual: Test scheduled send with `--delay`

🤖 Generated with [Claude Code](https://claude.com/claude-code)