### PR TITLE
feat: add --attach flag to reply, reply-all, and forward

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superhuman-cli",
-  "version": "0.13.3",
+  "version": "0.14.0",
   "module": "src/index.ts",
   "type": "module",
   "private": true,

--- a/src/__tests__/mcp-attachment-schemas.test.ts
+++ b/src/__tests__/mcp-attachment-schemas.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for attachment support in MCP reply/reply_all/forward schemas and handlers.
+ */
+import { test, expect, describe } from "bun:test";
+import { ReplySchema, ReplyAllSchema, ForwardSchema } from "../mcp/tools";
+
+describe("MCP schemas accept attachments", () => {
+  test("ReplySchema accepts optional attachments array", () => {
+    const result = ReplySchema.safeParse({
+      threadId: "t1",
+      body: "hello",
+      attachments: ["/tmp/file.pdf", "/tmp/file2.txt"],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.attachments).toEqual(["/tmp/file.pdf", "/tmp/file2.txt"]);
+    }
+  });
+
+  test("ReplySchema works without attachments", () => {
+    const result = ReplySchema.safeParse({
+      threadId: "t1",
+      body: "hello",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.attachments).toBeUndefined();
+    }
+  });
+
+  test("ReplyAllSchema accepts optional attachments array", () => {
+    const result = ReplyAllSchema.safeParse({
+      threadId: "t1",
+      body: "hello",
+      attachments: ["/tmp/file.pdf"],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.attachments).toEqual(["/tmp/file.pdf"]);
+    }
+  });
+
+  test("ReplyAllSchema works without attachments", () => {
+    const result = ReplyAllSchema.safeParse({
+      threadId: "t1",
+      body: "hello",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.attachments).toBeUndefined();
+    }
+  });
+
+  test("ForwardSchema accepts optional attachments array", () => {
+    const result = ForwardSchema.safeParse({
+      threadId: "t1",
+      toEmail: "user@example.com",
+      body: "hello",
+      attachments: ["/tmp/file.pdf"],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.attachments).toEqual(["/tmp/file.pdf"]);
+    }
+  });
+
+  test("ForwardSchema works without attachments", () => {
+    const result = ForwardSchema.safeParse({
+      threadId: "t1",
+      toEmail: "user@example.com",
+      body: "hello",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.attachments).toBeUndefined();
+    }
+  });
+});

--- a/src/__tests__/reply-attach.test.ts
+++ b/src/__tests__/reply-attach.test.ts
@@ -1,0 +1,436 @@
+import { test, expect, describe, afterEach } from "bun:test";
+import { readFileAsBase64 } from "../attachments";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const CLI = "src/cli.ts";
+const CWD = import.meta.dir + "/../..";
+
+function spawnCli(...args: string[]) {
+  return Bun.spawn([process.execPath, "run", CLI, ...args], {
+    cwd: CWD,
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+}
+
+async function getOutput(proc: ReturnType<typeof Bun.spawn>) {
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { stdout, stderr, output: stdout + stderr, exitCode };
+}
+
+describe("--attach flag parsing", () => {
+  test("--attach appears in help text", async () => {
+    const { stdout, exitCode } = await getOutput(spawnCli("--help"));
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--attach <path>");
+  });
+
+  test("parseArgs handles single --attach flag", async () => {
+    // reply with --attach should not error on the flag itself
+    // It will fail because no credentials, but the flag should be parsed (no "unknown" error)
+    const { output } = await getOutput(
+      spawnCli("reply", "thread123", "--body=Test", "--attach=/tmp/file.csv")
+    );
+    // Should NOT say "unknown option" or similar parse error for --attach
+    expect(output).not.toContain("unknown");
+    expect(output).not.toContain("Unknown option");
+  });
+
+  test("parseArgs handles multiple --attach flags", async () => {
+    const { output } = await getOutput(
+      spawnCli(
+        "reply",
+        "thread123",
+        "--body=Test",
+        "--attach=/tmp/file1.csv",
+        "--attach=/tmp/file2.pdf"
+      )
+    );
+    expect(output).not.toContain("unknown");
+    expect(output).not.toContain("Unknown option");
+  });
+
+  test("--attach works with forward command", async () => {
+    const { output } = await getOutput(
+      spawnCli(
+        "forward",
+        "thread123",
+        "--to=r@example.com",
+        "--body=FYI",
+        "--attach=/tmp/doc.pdf"
+      )
+    );
+    expect(output).not.toContain("unknown");
+    expect(output).not.toContain("Unknown option");
+  });
+
+  test("--attach works with reply-all command", async () => {
+    const { output } = await getOutput(
+      spawnCli(
+        "reply-all",
+        "thread123",
+        "--body=Test",
+        "--attach=/tmp/spreadsheet.xlsx"
+      )
+    );
+    expect(output).not.toContain("unknown");
+    expect(output).not.toContain("Unknown option");
+  });
+});
+
+describe("readFileAsBase64", () => {
+  test("reads a file and returns base64 data with filename and mimeType", async () => {
+    const tmpFile = join(tmpdir(), "test-attach.csv");
+    await Bun.write(tmpFile, "col1,col2\nval1,val2");
+
+    const result = await readFileAsBase64(tmpFile);
+    expect(result.filename).toBe("test-attach.csv");
+    expect(result.mimeType).toBe("text/csv");
+    expect(result.base64Data).toBeTruthy();
+
+    const decoded = Buffer.from(result.base64Data, "base64").toString("utf-8");
+    expect(decoded).toBe("col1,col2\nval1,val2");
+
+    await Bun.file(tmpFile).delete();
+  });
+
+  test("resolves ~ to home directory", async () => {
+    const home = process.env.HOME!;
+    const tmpFile = join(home, ".superhuman-test-attach.txt");
+    await Bun.write(tmpFile, "test content");
+
+    const result = await readFileAsBase64("~/.superhuman-test-attach.txt");
+    expect(result.filename).toBe(".superhuman-test-attach.txt");
+    expect(result.base64Data).toBeTruthy();
+
+    await Bun.file(tmpFile).delete();
+  });
+
+  test("throws error for non-existent file", async () => {
+    await expect(readFileAsBase64("/tmp/nonexistent-file-12345.txt")).rejects.toThrow();
+  });
+
+  test("detects common MIME types", async () => {
+    const tmpPdf = join(tmpdir(), "test.pdf");
+    await Bun.write(tmpPdf, "fake pdf");
+    const result = await readFileAsBase64(tmpPdf);
+    expect(result.mimeType).toBe("application/pdf");
+    await Bun.file(tmpPdf).delete();
+
+    const tmpDocx = join(tmpdir(), "test.docx");
+    await Bun.write(tmpDocx, "fake docx");
+    const result2 = await readFileAsBase64(tmpDocx);
+    expect(result2.mimeType).toBe("application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+    await Bun.file(tmpDocx).delete();
+  });
+});
+
+describe("forward with --attach integration", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("forward --attach creates draft via provider API and adds attachment", async () => {
+    const tmpFile = join(tmpdir(), "test-forward-attach.pdf");
+    await Bun.write(tmpFile, "fake pdf content");
+
+    const fetchCalls: { url: string; method: string; body?: string }[] = [];
+
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
+      fetchCalls.push({
+        url: urlStr,
+        method: init?.method || "GET",
+        body: typeof init?.body === "string" ? init.body : undefined,
+      });
+
+      // Mock Gmail thread info
+      if (urlStr.includes("/threads/") && !urlStr.includes("/drafts")) {
+        return new Response(JSON.stringify({
+          id: "thread123",
+          messages: [{
+            id: "msg001",
+            payload: {
+              headers: [
+                { name: "From", value: "sender@example.com" },
+                { name: "To", value: "me@example.com" },
+                { name: "Subject", value: "Original Subject" },
+                { name: "Message-ID", value: "<msg001@example.com>" },
+                { name: "References", value: "" },
+              ],
+            },
+          }],
+        }), { status: 200, headers: { "Content-Type": "application/json" } });
+      }
+
+      // Mock Gmail draft GET
+      if (urlStr.includes("/drafts/draft789") && (!init?.method || init?.method === "GET")) {
+        return new Response(JSON.stringify({
+          id: "draft789",
+          message: {
+            id: "draftmsg789",
+            payload: {
+              headers: [
+                { name: "To", value: "recipient@example.com" },
+                { name: "Subject", value: "Fwd: Original Subject" },
+                { name: "From", value: "me@example.com" },
+              ],
+              mimeType: "text/html",
+              body: {
+                data: Buffer.from("<p>FYI</p>").toString("base64url"),
+              },
+            },
+          },
+        }), { status: 200, headers: { "Content-Type": "application/json" } });
+      }
+
+      // Mock Gmail draft creation (POST /drafts) - forward creates a NEW draft, not a reply
+      if (urlStr.includes("/drafts") && init?.method === "POST" && !urlStr.includes("/send")) {
+        return new Response(JSON.stringify({
+          id: "draft789",
+          message: { id: "draftmsg789" },
+        }), { status: 200, headers: { "Content-Type": "application/json" } });
+      }
+
+      // Mock Gmail draft send
+      if (urlStr.includes("/drafts/send")) {
+        return new Response(JSON.stringify({
+          id: "sent999",
+          threadId: "thread123",
+        }), { status: 200, headers: { "Content-Type": "application/json" } });
+      }
+
+      // Mock Gmail draft PUT
+      if (urlStr.includes("/drafts/draft789") && init?.method === "PUT") {
+        return new Response(JSON.stringify({
+          id: "draft789",
+          message: { id: "draftmsg789" },
+        }), { status: 200, headers: { "Content-Type": "application/json" } });
+      }
+
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof globalThis.fetch;
+
+    const { readFileAsBase64: readFile } = await import("../attachments");
+    const {
+      createDraftDirect,
+      addAttachmentToDraft,
+      sendDraftDirect,
+    } = await import("../token-api");
+
+    // These functions must exist and be callable
+    expect(typeof createDraftDirect).toBe("function");
+    expect(typeof addAttachmentToDraft).toBe("function");
+    expect(typeof sendDraftDirect).toBe("function");
+
+    // Step 1: Read file as base64
+    const fileData = await readFile(tmpFile);
+    expect(fileData.filename).toBe("test-forward-attach.pdf");
+    expect(fileData.mimeType).toBe("application/pdf");
+
+    // Step 2: Create forward draft via provider API (NOT createReplyDraftDirect)
+    const fakeToken = {
+      accessToken: "fake-access-token",
+      email: "me@example.com",
+      userId: "user123",
+      idToken: "fake-id-token",
+      isMicrosoft: false,
+      superhumanAccountId: "acct123",
+    } as any;
+
+    const draft = await createDraftDirect(fakeToken, {
+      to: ["recipient@example.com"],
+      subject: "Fwd: Original Subject",
+      body: "<p>FYI</p>",
+      isHtml: true,
+    });
+    expect(draft).not.toBeNull();
+    expect(draft!.draftId).toBe("draft789");
+
+    // Step 3: Add attachment to draft
+    const attached = await addAttachmentToDraft(
+      fakeToken,
+      draft!.draftId,
+      fileData.filename,
+      fileData.mimeType,
+      fileData.base64Data
+    );
+    expect(fetchCalls.length).toBeGreaterThan(0);
+
+    // Step 4: Send draft
+    const sent = await sendDraftDirect(fakeToken, draft!.draftId);
+    expect(sent).not.toBeNull();
+
+    // Verify draft creation call was made (POST to /drafts)
+    const draftCreationCalls = fetchCalls.filter(c => c.url.includes("/drafts") && c.method === "POST");
+    expect(draftCreationCalls.length).toBeGreaterThan(0);
+
+    await Bun.file(tmpFile).delete();
+  });
+});
+
+describe("reply with --attach integration", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("reply --attach creates draft via provider API and adds attachment", async () => {
+    // Create a temp file to attach
+    const tmpFile = join(tmpdir(), "test-reply-attach.csv");
+    await Bun.write(tmpFile, "data1,data2");
+
+    const fetchCalls: { url: string; method: string; body?: string }[] = [];
+
+    // Mock fetch to simulate Gmail API calls
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
+      fetchCalls.push({
+        url: urlStr,
+        method: init?.method || "GET",
+        body: typeof init?.body === "string" ? init.body : undefined,
+      });
+
+      // Mock Gmail thread info
+      if (urlStr.includes("/threads/") && !urlStr.includes("/drafts")) {
+        return new Response(JSON.stringify({
+          id: "thread123",
+          messages: [{
+            id: "msg001",
+            payload: {
+              headers: [
+                { name: "From", value: "sender@example.com" },
+                { name: "To", value: "me@example.com" },
+                { name: "Subject", value: "Test Thread" },
+                { name: "Message-ID", value: "<msg001@example.com>" },
+                { name: "References", value: "" },
+              ],
+            },
+          }],
+        }), { status: 200, headers: { "Content-Type": "application/json" } });
+      }
+
+      // Mock Gmail draft GET (for addAttachmentToDraft reading the existing draft)
+      if (urlStr.includes("/drafts/draft456") && (!init?.method || init?.method === "GET")) {
+        return new Response(JSON.stringify({
+          id: "draft456",
+          message: {
+            id: "draftmsg456",
+            threadId: "thread123",
+            payload: {
+              headers: [
+                { name: "To", value: "sender@example.com" },
+                { name: "Subject", value: "Re: Test Thread" },
+                { name: "From", value: "me@example.com" },
+                { name: "In-Reply-To", value: "<msg001@example.com>" },
+                { name: "References", value: "<msg001@example.com>" },
+              ],
+              mimeType: "text/html",
+              body: {
+                data: Buffer.from("<p>Reply body</p>").toString("base64url"),
+              },
+            },
+          },
+        }), { status: 200, headers: { "Content-Type": "application/json" } });
+      }
+
+      // Mock Gmail draft creation (POST /drafts)
+      if (urlStr.includes("/drafts") && init?.method === "POST" && !urlStr.includes("/send")) {
+        return new Response(JSON.stringify({
+          id: "draft456",
+          message: { id: "draftmsg456", threadId: "thread123" },
+        }), { status: 200, headers: { "Content-Type": "application/json" } });
+      }
+
+      // Mock Gmail draft send
+      if (urlStr.includes("/drafts/send")) {
+        return new Response(JSON.stringify({
+          id: "sent789",
+          threadId: "thread123",
+        }), { status: 200, headers: { "Content-Type": "application/json" } });
+      }
+
+      // Mock Gmail draft PUT (for addAttachmentToDraft updating the draft)
+      if (urlStr.includes("/drafts/draft456") && init?.method === "PUT") {
+        return new Response(JSON.stringify({
+          id: "draft456",
+          message: { id: "draftmsg456", threadId: "thread123" },
+        }), { status: 200, headers: { "Content-Type": "application/json" } });
+      }
+
+      // Default response
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof globalThis.fetch;
+
+    // Verify the building blocks work together
+    const { readFileAsBase64: readFile } = await import("../attachments");
+    const {
+      createReplyDraftDirect,
+      addAttachmentToDraft,
+      sendDraftDirect,
+    } = await import("../token-api");
+
+    // These functions must exist and be callable (the actual API is mocked)
+    expect(typeof createReplyDraftDirect).toBe("function");
+    expect(typeof addAttachmentToDraft).toBe("function");
+    expect(typeof sendDraftDirect).toBe("function");
+
+    // Step 1: Read file as base64
+    const fileData = await readFile(tmpFile);
+    expect(fileData.filename).toBe("test-reply-attach.csv");
+    expect(fileData.mimeType).toBe("text/csv");
+
+    // Step 2: Create reply draft via provider API (Gmail)
+    const fakeToken = {
+      accessToken: "fake-access-token",
+      email: "me@example.com",
+      userId: "user123",
+      idToken: "fake-id-token",
+      isMicrosoft: false,
+      superhumanAccountId: "acct123",
+    } as any;
+
+    const draft = await createReplyDraftDirect(fakeToken, "thread123", "<p>Reply body</p>", {
+      replyAll: false,
+      isHtml: true,
+    });
+    expect(draft).not.toBeNull();
+    expect(draft!.draftId).toBe("draft456");
+
+    // Step 3: Add attachment to draft
+    const attached = await addAttachmentToDraft(
+      fakeToken,
+      draft!.draftId,
+      fileData.filename,
+      fileData.mimeType,
+      fileData.base64Data
+    );
+    // With our mock, this should have made a fetch call
+    expect(fetchCalls.length).toBeGreaterThan(0);
+
+    // Step 4: Send draft
+    const sent = await sendDraftDirect(fakeToken, draft!.draftId);
+    expect(sent).not.toBeNull();
+
+    // Verify the API call sequence includes draft creation and send
+    const draftCreationCalls = fetchCalls.filter(c => c.url.includes("/drafts") && c.method === "POST");
+    expect(draftCreationCalls.length).toBeGreaterThan(0);
+
+    await Bun.file(tmpFile).delete();
+  });
+});

--- a/src/attachments.ts
+++ b/src/attachments.ts
@@ -33,6 +33,63 @@ export interface AddAttachmentResult {
   error?: string;
 }
 
+export interface FileAttachmentData {
+  filename: string;
+  base64Data: string;
+  mimeType: string;
+}
+
+const MIME_TYPES: Record<string, string> = {
+  csv: "text/csv",
+  txt: "text/plain",
+  html: "text/html",
+  pdf: "application/pdf",
+  json: "application/json",
+  xml: "application/xml",
+  zip: "application/zip",
+  gz: "application/gzip",
+  doc: "application/msword",
+  docx: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  xls: "application/vnd.ms-excel",
+  xlsx: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  ppt: "application/vnd.ms-powerpoint",
+  pptx: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  svg: "image/svg+xml",
+  mp3: "audio/mpeg",
+  mp4: "video/mp4",
+};
+
+/**
+ * Read a file from disk and return its content as base64 with metadata.
+ */
+export async function readFileAsBase64(filePath: string): Promise<FileAttachmentData> {
+  let resolved = filePath;
+  if (resolved.startsWith("~/")) {
+    resolved = resolved.replace("~", process.env.HOME || "");
+  }
+
+  const { resolve, basename } = await import("path");
+  resolved = resolve(resolved);
+
+  const file = Bun.file(resolved);
+  if (!(await file.exists())) {
+    throw new Error(`File not found: ${filePath}`);
+  }
+
+  const bytes = await file.bytes();
+  const base64Data = Buffer.from(bytes).toString("base64");
+
+  const filename = basename(resolved);
+  const ext = getExtension(filename);
+  const mimeType = MIME_TYPES[ext] || "application/octet-stream";
+
+  return { filename, base64Data, mimeType };
+}
+
 /**
  * Extract file extension from filename.
  */

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,7 +26,7 @@ import { archiveThread, deleteThread } from "./archive";
 import { markAsRead, markAsUnread } from "./read-status";
 import { listLabels, getThreadLabels, addLabel, removeLabel, starThread, unstarThread, listStarred } from "./labels";
 import { parseSnoozeTime, snoozeThreadViaProvider, unsnoozeThreadViaProvider, listSnoozedViaProvider } from "./snooze";
-import { listAttachments, downloadAttachment } from "./attachments";
+import { listAttachments, downloadAttachment, readFileAsBase64 } from "./attachments";
 import {
   listEvents,
   createEvent,
@@ -58,6 +58,10 @@ import {
   getThreadMessages,
   listDraftsDirect,
   extractTokenChrome,
+  createReplyDraftDirect,
+  createDraftDirect,
+  addAttachmentToDraft,
+  sendDraftDirect,
   type TokenInfo,
 } from "./token-api";
 import type { ConnectionProvider } from "./connection-provider";
@@ -67,7 +71,7 @@ import { GmailDraftProvider } from "./providers/gmail-draft-provider";
 import { OutlookDraftProvider } from "./providers/outlook-draft-provider";
 import { SuperhumanDraftProvider } from "./providers/superhuman-draft-provider";
 
-const VERSION = "0.13.3";
+const VERSION = "0.14.0";
 const CDP_PORT = parseInt(process.env.CDP_PORT || "9400", 10);
 
 // ANSI colors
@@ -167,6 +171,7 @@ ${colors.bold}OPTIONS${colors.reset}
   --subject <text>   Email subject
   --body <text>      Email body (plain text, converted to HTML)
   --html <text>      Email body as HTML
+  --attach <path>    Attach a file (can be used multiple times, for reply/reply-all/forward)
   --send             Send immediately instead of saving as draft (for reply/reply-all/forward)
   --vars <pairs>     Template variable substitution: "key1=val1,key2=val2" (for snippet use)
   --provider <type>  Draft API: "superhuman" (default), "gmail", or "outlook"
@@ -383,6 +388,8 @@ interface CliOptions {
   provider: "superhuman" | "gmail" | "outlook"; // which API to use for drafts (default: superhuman)
   // native draft flag
   native: boolean; // use native Superhuman draft operations (for update/delete)
+  // file attachment options
+  attachFiles: string[]; // file paths to attach (for reply/reply-all/forward)
 }
 
 function parseArgs(args: string[]): CliOptions {
@@ -433,6 +440,7 @@ function parseArgs(args: string[]): CliOptions {
     context: 0,
     provider: "superhuman",
     native: false,
+    attachFiles: [],
   };
 
   let i = 0;
@@ -535,6 +543,10 @@ function parseArgs(args: string[]): CliOptions {
           break;
         case "attachment":
           options.attachmentId = unescapeString(value);
+          i += inc;
+          break;
+        case "attach":
+          options.attachFiles.push(unescapeString(value));
           i += inc;
           break;
         case "message":
@@ -1646,6 +1658,57 @@ async function cmdReply(options: CliOptions) {
     if (token) {
       const body = options.body || "";
 
+      const hasAttachments = options.attachFiles && options.attachFiles.length > 0;
+
+      if (hasAttachments) {
+        // Attachment path: use provider API (Gmail/MS Graph) instead of Superhuman native
+        const action = options.send ? "Sending" : "Creating draft for";
+        info(`${action} reply with ${options.attachFiles.length} attachment(s) via provider API...`);
+
+        const htmlBody = textToHtml(body);
+        const draft = await createReplyDraftDirect(token, options.threadId, htmlBody, {
+          replyAll: false,
+          isHtml: true,
+        });
+
+        if (!draft) {
+          error("Failed to create reply draft via provider API");
+          process.exit(1);
+        }
+
+        // Add each attachment
+        for (const filePath of options.attachFiles) {
+          const fileData = await readFileAsBase64(filePath);
+          info(`Attaching ${fileData.filename} (${fileData.mimeType})...`);
+          const attached = await addAttachmentToDraft(
+            token,
+            draft.draftId,
+            fileData.filename,
+            fileData.mimeType,
+            fileData.base64Data
+          );
+          if (!attached) {
+            error(`Failed to attach ${fileData.filename}`);
+            process.exit(1);
+          }
+        }
+
+        if (options.send) {
+          const sent = await sendDraftDirect(token, draft.draftId);
+          if (sent) {
+            success("Reply with attachment(s) sent!");
+            log(`  ${colors.dim}Account: ${token.email}${colors.reset}`);
+          } else {
+            error("Failed to send reply draft");
+          }
+        } else {
+          success("Reply draft with attachment(s) created!");
+          log(`  ${colors.dim}Draft ID: ${draft.draftId}${colors.reset}`);
+          log(`  ${colors.dim}Account: ${token.email}${colors.reset}`);
+        }
+        return;
+      }
+
       if (options.send) {
         info(`Sending reply to thread ${options.threadId} via direct API...`);
 
@@ -1753,6 +1816,57 @@ async function cmdReplyAll(options: CliOptions) {
     const token = await resolveSuperhumanToken(options.account);
     if (token) {
       const body = options.body || "";
+
+      const hasAttachments = options.attachFiles && options.attachFiles.length > 0;
+
+      if (hasAttachments) {
+        // Attachment path: use provider API (Gmail/MS Graph) instead of Superhuman native
+        const action = options.send ? "Sending" : "Creating draft for";
+        info(`${action} reply-all with ${options.attachFiles.length} attachment(s) via provider API...`);
+
+        const htmlBody = textToHtml(body);
+        const draft = await createReplyDraftDirect(token, options.threadId, htmlBody, {
+          replyAll: true,
+          isHtml: true,
+        });
+
+        if (!draft) {
+          error("Failed to create reply-all draft via provider API");
+          process.exit(1);
+        }
+
+        // Add each attachment
+        for (const filePath of options.attachFiles) {
+          const fileData = await readFileAsBase64(filePath);
+          info(`Attaching ${fileData.filename} (${fileData.mimeType})...`);
+          const attached = await addAttachmentToDraft(
+            token,
+            draft.draftId,
+            fileData.filename,
+            fileData.mimeType,
+            fileData.base64Data
+          );
+          if (!attached) {
+            error(`Failed to attach ${fileData.filename}`);
+            process.exit(1);
+          }
+        }
+
+        if (options.send) {
+          const sent = await sendDraftDirect(token, draft.draftId);
+          if (sent) {
+            success("Reply-all with attachment(s) sent!");
+            log(`  ${colors.dim}Account: ${token.email}${colors.reset}`);
+          } else {
+            error("Failed to send reply-all draft");
+          }
+        } else {
+          success("Reply-all draft with attachment(s) created!");
+          log(`  ${colors.dim}Draft ID: ${draft.draftId}${colors.reset}`);
+          log(`  ${colors.dim}Account: ${token.email}${colors.reset}`);
+        }
+        return;
+      }
 
       if (options.send) {
         info(`Sending reply-all to thread ${options.threadId} via direct API...`);
@@ -1887,6 +2001,69 @@ async function cmdForward(options: CliOptions) {
     const token = await resolveSuperhumanToken(options.account);
     if (token) {
       const body = options.body || "";
+
+      const hasAttachments = options.attachFiles && options.attachFiles.length > 0;
+
+      if (hasAttachments) {
+        // Attachment path: use provider API (Gmail/MS Graph) instead of Superhuman native
+        const action = options.send ? "Sending" : "Creating draft for";
+        info(`${action} forward with ${options.attachFiles.length} attachment(s) via provider API...`);
+
+        const threadInfo = await getThreadInfoDirect(token, options.threadId);
+        if (!threadInfo) {
+          error("Could not get thread information");
+          process.exit(1);
+        }
+
+        const subject = threadInfo.subject.startsWith("Fwd:")
+          ? threadInfo.subject
+          : `Fwd: ${threadInfo.subject}`;
+
+        // Forwards are new threads, so use createDraftDirect (not createReplyDraftDirect)
+        const draft = await createDraftDirect(token, {
+          to: options.to,
+          subject,
+          body: textToHtml(body),
+          isHtml: true,
+        });
+
+        if (!draft) {
+          error("Failed to create forward draft via provider API");
+          process.exit(1);
+        }
+
+        // Add each attachment
+        for (const filePath of options.attachFiles) {
+          const fileData = await readFileAsBase64(filePath);
+          info(`Attaching ${fileData.filename} (${fileData.mimeType})...`);
+          const attached = await addAttachmentToDraft(
+            token,
+            draft.draftId,
+            fileData.filename,
+            fileData.mimeType,
+            fileData.base64Data
+          );
+          if (!attached) {
+            error(`Failed to attach ${fileData.filename}`);
+            process.exit(1);
+          }
+        }
+
+        if (options.send) {
+          const sent = await sendDraftDirect(token, draft.draftId);
+          if (sent) {
+            success("Forward with attachment(s) sent!");
+            log(`  ${colors.dim}Account: ${token.email}${colors.reset}`);
+          } else {
+            error("Failed to send forward draft");
+          }
+        } else {
+          success("Forward draft with attachment(s) created!");
+          log(`  ${colors.dim}Draft ID: ${draft.draftId}${colors.reset}`);
+          log(`  ${colors.dim}Account: ${token.email}${colors.reset}`);
+        }
+        return;
+      }
 
       if (options.send) {
         info(`Forwarding thread ${options.threadId} via direct API...`);

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -19,7 +19,7 @@ import { archiveThread, deleteThread } from "../archive";
 import { markAsRead, markAsUnread } from "../read-status";
 import { listLabels, getThreadLabels, addLabel, removeLabel, starThread, unstarThread, listStarred } from "../labels";
 import { parseSnoozeTime, snoozeThreadViaProvider, unsnoozeThreadViaProvider, listSnoozedViaProvider } from "../snooze";
-import { listAttachments, downloadAttachment } from "../attachments";
+import { listAttachments, downloadAttachment, readFileAsBase64 } from "../attachments";
 import {
   listEvents,
   createEvent,
@@ -39,6 +39,9 @@ import {
   getCachedAccounts,
   hasCachedSuperhumanCredentials,
   askAISearch,
+  createReplyDraftDirect,
+  addAttachmentToDraft,
+  sendDraftDirect,
   type TokenInfo,
 } from "../token-api";
 
@@ -115,6 +118,7 @@ export const ReplySchema = z.object({
   threadId: z.string().describe("Thread ID to reply to"),
   body: z.string().describe("Reply message body"),
   send: z.boolean().optional().describe("Send immediately instead of creating draft (default: false)"),
+  attachments: z.array(z.string()).optional().describe("File paths to attach"),
 });
 
 /**
@@ -124,6 +128,7 @@ export const ReplyAllSchema = z.object({
   threadId: z.string().describe("Thread ID to reply-all to"),
   body: z.string().describe("Reply message body"),
   send: z.boolean().optional().describe("Send immediately instead of creating draft (default: false)"),
+  attachments: z.array(z.string()).optional().describe("File paths to attach"),
 });
 
 /**
@@ -134,6 +139,7 @@ export const ForwardSchema = z.object({
   toEmail: z.string().describe("Email address to forward to"),
   body: z.string().describe("Message body to include before the forwarded content"),
   send: z.boolean().optional().describe("Send immediately instead of creating draft (default: false)"),
+  attachments: z.array(z.string()).optional().describe("File paths to attach"),
 });
 
 /**
@@ -607,6 +613,33 @@ export async function replyHandler(args: z.infer<typeof ReplySchema>): Promise<T
   try {
     provider = await getMcpProvider();
     const send = args.send ?? false;
+    const hasAttachments = args.attachments && args.attachments.length > 0;
+
+    if (hasAttachments) {
+      // When attachments are present, use direct API to create draft, attach, then optionally send
+      const token = await provider.getToken();
+      const htmlBody = textToHtml(args.body);
+      const draft = await createReplyDraftDirect(token, args.threadId, htmlBody, { replyAll: false, isHtml: true });
+      if (!draft) {
+        throw new Error("Failed to create reply draft");
+      }
+
+      for (const filePath of args.attachments!) {
+        const fileData = await readFileAsBase64(filePath);
+        await addAttachmentToDraft(token, draft.draftId, fileData.filename, fileData.mimeType, fileData.base64Data);
+      }
+
+      if (send) {
+        const sendResult = await sendDraftDirect(token, draft.draftId);
+        if (!sendResult) {
+          throw new Error("Failed to send reply with attachments");
+        }
+        return successResult(`Reply with ${args.attachments!.length} attachment(s) sent successfully to thread ${args.threadId}`);
+      }
+      return successResult(`Reply draft with ${args.attachments!.length} attachment(s) created for thread ${args.threadId}\nDraft ID: ${draft.draftId}`);
+    }
+
+    // No attachments: use existing logic
     const result = await replyToThread(provider, args.threadId, args.body, send);
 
     if (!result.success) {
@@ -635,6 +668,33 @@ export async function replyAllHandler(args: z.infer<typeof ReplyAllSchema>): Pro
   try {
     provider = await getMcpProvider();
     const send = args.send ?? false;
+    const hasAttachments = args.attachments && args.attachments.length > 0;
+
+    if (hasAttachments) {
+      // When attachments are present, use direct API to create draft, attach, then optionally send
+      const token = await provider.getToken();
+      const htmlBody = textToHtml(args.body);
+      const draft = await createReplyDraftDirect(token, args.threadId, htmlBody, { replyAll: true, isHtml: true });
+      if (!draft) {
+        throw new Error("Failed to create reply-all draft");
+      }
+
+      for (const filePath of args.attachments!) {
+        const fileData = await readFileAsBase64(filePath);
+        await addAttachmentToDraft(token, draft.draftId, fileData.filename, fileData.mimeType, fileData.base64Data);
+      }
+
+      if (send) {
+        const sendResult = await sendDraftDirect(token, draft.draftId);
+        if (!sendResult) {
+          throw new Error("Failed to send reply-all with attachments");
+        }
+        return successResult(`Reply-all with ${args.attachments!.length} attachment(s) sent successfully to thread ${args.threadId}`);
+      }
+      return successResult(`Reply-all draft with ${args.attachments!.length} attachment(s) created for thread ${args.threadId}\nDraft ID: ${draft.draftId}`);
+    }
+
+    // No attachments: use existing logic
     const result = await replyAllToThread(provider, args.threadId, args.body, send);
 
     if (!result.success) {
@@ -663,6 +723,32 @@ export async function forwardHandler(args: z.infer<typeof ForwardSchema>): Promi
   try {
     provider = await getMcpProvider();
     const send = args.send ?? false;
+    const hasAttachments = args.attachments && args.attachments.length > 0;
+
+    if (hasAttachments) {
+      // When attachments are present, create draft first, attach files, then optionally send
+      const result = await forwardThread(provider, args.threadId, args.toEmail, args.body, false);
+      if (!result.success || !result.draftId) {
+        throw new Error(result.error || "Failed to create forward draft");
+      }
+
+      const token = await provider.getToken();
+      for (const filePath of args.attachments!) {
+        const fileData = await readFileAsBase64(filePath);
+        await addAttachmentToDraft(token, result.draftId, fileData.filename, fileData.mimeType, fileData.base64Data);
+      }
+
+      if (send) {
+        const sendResult = await sendDraftDirect(token, result.draftId);
+        if (!sendResult) {
+          throw new Error("Failed to send forward with attachments");
+        }
+        return successResult(`Email with ${args.attachments!.length} attachment(s) forwarded successfully to ${args.toEmail}`);
+      }
+      return successResult(`Forward draft with ${args.attachments!.length} attachment(s) created for ${args.toEmail}\nDraft ID: ${result.draftId}`);
+    }
+
+    // No attachments: use existing logic
     const result = await forwardThread(provider, args.threadId, args.toEmail, args.body, send);
 
     if (!result.success) {


### PR DESCRIPTION
## Summary
- Adds `--attach <path>` flag to `reply`, `reply-all`, and `forward` CLI commands (repeatable for multiple files)
- Uses provider API (Gmail/MS Graph) draft-then-attach pattern since Superhuman native API does not support attachments
- Adds `attachments` field to MCP tool schemas (`reply`, `reply_all`, `forward`)
- Includes `readFileAsBase64()` helper with MIME type detection and `~` expansion

Closes #16

## Test plan
- [x] 11 new tests in `reply-attach.test.ts` (flag parsing, file reading, reply/forward integration)
- [x] 6 new tests in `mcp-attachment-schemas.test.ts` (schema validation)
- [x] Full suite: 160/161 pass (1 pre-existing CDP timeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)