### PR TITLE
fix(send): reliable send-draft + draft-list crash fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superhuman-cli",
-  "version": "0.30.5",
+  "version": "0.30.6",
   "module": "src/index.ts",
   "type": "module",
   "private": true,

--- a/src/__tests__/send-backend.test.ts
+++ b/src/__tests__/send-backend.test.ts
@@ -255,6 +255,53 @@ describe("send-api with SuperhumanProvider", () => {
     }
   });
 
+  test("sendDraftByIdViaProvider sends a Gmail reply with real per-message ids (guard does not misfire)", async () => {
+    // Gmail regression: a Gmail reply's replyItemIds are real per-message ids,
+    // DISTINCT from the (hex) threadId. The silent-delivery guard refuses only
+    // when replyItemIds === [threadId] (the MS no-per-message-id fallback), so
+    // it must NOT block a valid Gmail reply. Guards against a provider-specific
+    // regression where Gmail sends get wrongly refused or sent without threading.
+    const tmp = mkdtempSync(join(tmpdir(), "sh-cli-draft-"));
+    const prevCfg = process.env.SUPERHUMAN_CLI_CONFIG_DIR;
+    process.env.SUPERHUMAN_CLI_CONFIG_DIR = tmp;
+    try {
+      const draftId = "draft00gmailrep";
+      const meta = {
+        draftId,
+        threadId: "19e944aeb93de925", // Gmail thread id (hex)
+        to: ["Nadya Malenko <malenko@bc.edu>"],
+        subject: "Re: paper",
+        htmlBody: "<p>Thanks!</p>",
+        inReplyTo: "<CABc123@mail.gmail.com>",
+        inReplyToItemId: "19e951ed105d2b06", // Gmail message id, != threadId
+        references: ["<CABc000@mail.gmail.com>"],
+        createdAt: new Date().toISOString(),
+        replyItemIds: ["19e951ed105d2b06"],
+      };
+      writeFileSync(join(tmp, "draft-cache.json"), JSON.stringify({ [draftId]: meta }));
+
+      const { calls, getSendBody } = setupCapturingMockFetch();
+      const provider = new SuperhumanProvider(sampleToken);
+
+      const result = await sendDraftByIdViaProvider(provider, draftId);
+
+      expect(result.success).toBe(true);
+      expect(calls.find((c) => c.includes("messages/send"))).toBeDefined();
+
+      const om = getSendBody()?.outgoing_message;
+      expect(om).toBeTruthy();
+      expect(om.thread_id).toBe("19e944aeb93de925");
+      expect(om.to).toEqual([{ email: "malenko@bc.edu", name: "Nadya Malenko" }]);
+      expect(om.in_reply_to).toBe("19e951ed105d2b06");
+      // Real per-message id + draft id — the guard let it through (threadId not appended).
+      expect(om.current_message_ids).toEqual(["19e951ed105d2b06", draftId]);
+    } finally {
+      if (prevCfg === undefined) delete process.env.SUPERHUMAN_CLI_CONFIG_DIR;
+      else process.env.SUPERHUMAN_CLI_CONFIG_DIR = prevCfg;
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   test("sendDraftByIdViaProvider refuses when no cached metadata exists (no blind empty send)", async () => {
     const tmp = mkdtempSync(join(tmpdir(), "sh-cli-draft-"));
     const prevCfg = process.env.SUPERHUMAN_CLI_CONFIG_DIR;

--- a/src/__tests__/send-backend.test.ts
+++ b/src/__tests__/send-backend.test.ts
@@ -13,6 +13,9 @@ import {
   sendDraftByIdViaProvider,
 } from "../send-api";
 import { replyToThread, replyAllToThread, forwardThread, _testHooks } from "../reply";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 
 const sampleToken: SuperhumanTokenInfo = {
   token: "test-jwt-token",
@@ -158,16 +161,154 @@ describe("send-api with SuperhumanProvider", () => {
 
   // ---- sendDraftByIdViaProvider ----
 
-  test("sendDraftByIdViaProvider with SuperhumanProvider sends existing draft", async () => {
-    const { calls } = setupMockFetch();
-    const provider = new SuperhumanProvider(sampleToken);
+  /** Capture the JSON body of the /messages/send POST for payload assertions. */
+  function setupCapturingMockFetch() {
+    const calls: string[] = [];
+    let sendBody: any = null;
+    const mockFn = mock((url: string | URL | Request, init?: RequestInit) => {
+      const urlStr =
+        typeof url === "string" ? url : url instanceof URL ? url.toString() : (url as Request).url;
+      calls.push(urlStr);
+      if (urlStr.includes("messages/send") && !urlStr.includes("/log")) {
+        try {
+          sendBody = JSON.parse((init?.body as string) ?? "{}");
+        } catch {
+          sendBody = null;
+        }
+        return Promise.resolve(
+          new Response(JSON.stringify({ send_at: Date.now() }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        );
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify({}), { status: 200, headers: { "Content-Type": "application/json" } })
+      );
+    });
+    globalThis.fetch = mockFn as any;
+    return { calls, getSendBody: () => sendBody };
+  }
 
-    const result = await sendDraftByIdViaProvider(provider, "draft00abc123");
+  test("sendDraftByIdViaProvider sends the full cached payload (recipients, body, attachment, threading)", async () => {
+    // Isolate the draft cache to a temp dir so loadDraftMeta() reads our fixture.
+    const tmp = mkdtempSync(join(tmpdir(), "sh-cli-draft-"));
+    const prevCfg = process.env.SUPERHUMAN_CLI_CONFIG_DIR;
+    process.env.SUPERHUMAN_CLI_CONFIG_DIR = tmp;
+    try {
+      const draftId = "draft00abc123";
+      const meta = {
+        draftId,
+        threadId: "AAQkThreadRealId==",
+        to: ["Reynolds W. Holding <rh2804@columbia.edu>"],
+        subject: "Re: Mirror Voting",
+        htmlBody: "<p>Hi Ren,</p>",
+        inReplyTo: "<orig@mail.gmail.com>",
+        inReplyToItemId: "AAkItem3",
+        references: ["<r1@x.com>"],
+        createdAt: new Date().toISOString(),
+        replyItemIds: ["AAkItem1", "AAkItem2", "AAkItem3"],
+        attachments: [
+          {
+            uuid: "uuid-1",
+            name: "post.docx",
+            type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            inline: false,
+            downloadUrl: "https://media.superhuman.com/x",
+            cid: "cid-1",
+            threadId: "AAQkThreadRealId==",
+            messageId: draftId,
+            size: 1234,
+          },
+        ],
+      };
+      writeFileSync(join(tmp, "draft-cache.json"), JSON.stringify({ [draftId]: meta }));
 
-    expect(result.success).toBe(true);
-    expect(result.messageId).toBe("draft00abc123");
-    const sendCall = calls.find((c) => c.includes("messages/send"));
-    expect(sendCall).toBeDefined();
+      const { calls, getSendBody } = setupCapturingMockFetch();
+      const provider = new SuperhumanProvider(sampleToken);
+
+      const result = await sendDraftByIdViaProvider(provider, draftId);
+
+      expect(result.success).toBe(true);
+      expect(result.messageId).toBe(draftId);
+      expect(calls.find((c) => c.includes("messages/send"))).toBeDefined();
+
+      const om = getSendBody()?.outgoing_message;
+      expect(om).toBeTruthy();
+      // Real thread id — NOT the draft id (the old bug used draftId here).
+      expect(om.thread_id).toBe("AAQkThreadRealId==");
+      // Recipients carried through (old bug sent to:[]).
+      expect(om.to).toEqual([{ email: "rh2804@columbia.edu", name: "Reynolds W. Holding" }]);
+      expect(om.subject).toBe("Re: Mirror Voting");
+      expect(om.html_body).toBe("<p>Hi Ren,</p>");
+      // Reply threading + the silent-failure fix.
+      expect(om.in_reply_to).toBe("AAkItem3");
+      expect(om.current_message_ids).toEqual(["AAkItem1", "AAkItem2", "AAkItem3", draftId]);
+      // Attachment re-included.
+      expect(om.attachments).toHaveLength(1);
+      expect(om.attachments[0].uuid).toBe("uuid-1");
+      expect(om.attachments[0].source.message_id).toBe(draftId);
+    } finally {
+      if (prevCfg === undefined) delete process.env.SUPERHUMAN_CLI_CONFIG_DIR;
+      else process.env.SUPERHUMAN_CLI_CONFIG_DIR = prevCfg;
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("sendDraftByIdViaProvider refuses when no cached metadata exists (no blind empty send)", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "sh-cli-draft-"));
+    const prevCfg = process.env.SUPERHUMAN_CLI_CONFIG_DIR;
+    process.env.SUPERHUMAN_CLI_CONFIG_DIR = tmp; // empty cache dir
+    try {
+      const { calls } = setupCapturingMockFetch();
+      const provider = new SuperhumanProvider(sampleToken);
+
+      const result = await sendDraftByIdViaProvider(provider, "draft00missing");
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("No cached metadata");
+      // Must NOT have hit the send endpoint.
+      expect(calls.find((c) => c.includes("messages/send"))).toBeUndefined();
+    } finally {
+      if (prevCfg === undefined) delete process.env.SUPERHUMAN_CLI_CONFIG_DIR;
+      else process.env.SUPERHUMAN_CLI_CONFIG_DIR = prevCfg;
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("sendDraftByIdViaProvider refuses a reply whose only thread id is the conversation id", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "sh-cli-draft-"));
+    const prevCfg = process.env.SUPERHUMAN_CLI_CONFIG_DIR;
+    process.env.SUPERHUMAN_CLI_CONFIG_DIR = tmp;
+    try {
+      const draftId = "draft00guard";
+      writeFileSync(
+        join(tmp, "draft-cache.json"),
+        JSON.stringify({
+          [draftId]: {
+            draftId,
+            threadId: "CONV==",
+            to: ["a@b.com"],
+            subject: "Re: x",
+            htmlBody: "<p>hi</p>",
+            createdAt: new Date().toISOString(),
+            replyItemIds: ["CONV=="], // only the conversation id → would fail silently
+          },
+        })
+      );
+      const { calls } = setupCapturingMockFetch();
+      const provider = new SuperhumanProvider(sampleToken);
+
+      const result = await sendDraftByIdViaProvider(provider, draftId);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Refusing to send");
+      expect(calls.find((c) => c.includes("messages/send"))).toBeUndefined();
+    } finally {
+      if (prevCfg === undefined) delete process.env.SUPERHUMAN_CLI_CONFIG_DIR;
+      else process.env.SUPERHUMAN_CLI_CONFIG_DIR = prevCfg;
+      rmSync(tmp, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/__tests__/send-backend.test.ts
+++ b/src/__tests__/send-backend.test.ts
@@ -10,12 +10,9 @@ import type { SuperhumanTokenInfo } from "../superhuman-provider";
 import {
   sendEmailViaProvider,
   createDraftViaProvider,
-  sendDraftByIdViaProvider,
 } from "../send-api";
+import { buildSendDraftOptions, type Recipient, type SuperhumanAttachment } from "../draft-api";
 import { replyToThread, replyAllToThread, forwardThread, _testHooks } from "../reply";
-import { mkdtempSync, writeFileSync, rmSync } from "fs";
-import { tmpdir } from "os";
-import { join } from "path";
 
 const sampleToken: SuperhumanTokenInfo = {
   token: "test-jwt-token",
@@ -159,204 +156,6 @@ describe("send-api with SuperhumanProvider", () => {
     expect(sendCall).toBeUndefined();
   });
 
-  // ---- sendDraftByIdViaProvider ----
-
-  /** Capture the JSON body of the /messages/send POST for payload assertions. */
-  function setupCapturingMockFetch() {
-    const calls: string[] = [];
-    let sendBody: any = null;
-    const mockFn = mock((url: string | URL | Request, init?: RequestInit) => {
-      const urlStr =
-        typeof url === "string" ? url : url instanceof URL ? url.toString() : (url as Request).url;
-      calls.push(urlStr);
-      if (urlStr.includes("messages/send") && !urlStr.includes("/log")) {
-        try {
-          sendBody = JSON.parse((init?.body as string) ?? "{}");
-        } catch {
-          sendBody = null;
-        }
-        return Promise.resolve(
-          new Response(JSON.stringify({ send_at: Date.now() }), {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          })
-        );
-      }
-      return Promise.resolve(
-        new Response(JSON.stringify({}), { status: 200, headers: { "Content-Type": "application/json" } })
-      );
-    });
-    globalThis.fetch = mockFn as any;
-    return { calls, getSendBody: () => sendBody };
-  }
-
-  test("sendDraftByIdViaProvider sends the full cached payload (recipients, body, attachment, threading)", async () => {
-    // Isolate the draft cache to a temp dir so loadDraftMeta() reads our fixture.
-    const tmp = mkdtempSync(join(tmpdir(), "sh-cli-draft-"));
-    const prevCfg = process.env.SUPERHUMAN_CLI_CONFIG_DIR;
-    process.env.SUPERHUMAN_CLI_CONFIG_DIR = tmp;
-    try {
-      const draftId = "draft00abc123";
-      const meta = {
-        draftId,
-        threadId: "AAQkThreadRealId==",
-        to: ["Reynolds W. Holding <rh2804@columbia.edu>"],
-        subject: "Re: Mirror Voting",
-        htmlBody: "<p>Hi Ren,</p>",
-        inReplyTo: "<orig@mail.gmail.com>",
-        inReplyToItemId: "AAkItem3",
-        references: ["<r1@x.com>"],
-        createdAt: new Date().toISOString(),
-        replyItemIds: ["AAkItem1", "AAkItem2", "AAkItem3"],
-        attachments: [
-          {
-            uuid: "uuid-1",
-            name: "post.docx",
-            type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-            inline: false,
-            downloadUrl: "https://media.superhuman.com/x",
-            cid: "cid-1",
-            threadId: "AAQkThreadRealId==",
-            messageId: draftId,
-            size: 1234,
-          },
-        ],
-      };
-      writeFileSync(join(tmp, "draft-cache.json"), JSON.stringify({ [draftId]: meta }));
-
-      const { calls, getSendBody } = setupCapturingMockFetch();
-      const provider = new SuperhumanProvider(sampleToken);
-
-      const result = await sendDraftByIdViaProvider(provider, draftId);
-
-      expect(result.success).toBe(true);
-      expect(result.messageId).toBe(draftId);
-      expect(calls.find((c) => c.includes("messages/send"))).toBeDefined();
-
-      const om = getSendBody()?.outgoing_message;
-      expect(om).toBeTruthy();
-      // Real thread id — NOT the draft id (the old bug used draftId here).
-      expect(om.thread_id).toBe("AAQkThreadRealId==");
-      // Recipients carried through (old bug sent to:[]).
-      expect(om.to).toEqual([{ email: "rh2804@columbia.edu", name: "Reynolds W. Holding" }]);
-      expect(om.subject).toBe("Re: Mirror Voting");
-      expect(om.html_body).toBe("<p>Hi Ren,</p>");
-      // Reply threading + the silent-failure fix.
-      expect(om.in_reply_to).toBe("AAkItem3");
-      expect(om.current_message_ids).toEqual(["AAkItem1", "AAkItem2", "AAkItem3", draftId]);
-      // Attachment re-included.
-      expect(om.attachments).toHaveLength(1);
-      expect(om.attachments[0].uuid).toBe("uuid-1");
-      expect(om.attachments[0].source.message_id).toBe(draftId);
-    } finally {
-      if (prevCfg === undefined) delete process.env.SUPERHUMAN_CLI_CONFIG_DIR;
-      else process.env.SUPERHUMAN_CLI_CONFIG_DIR = prevCfg;
-      rmSync(tmp, { recursive: true, force: true });
-    }
-  });
-
-  test("sendDraftByIdViaProvider sends a Gmail reply with real per-message ids (guard does not misfire)", async () => {
-    // Gmail regression: a Gmail reply's replyItemIds are real per-message ids,
-    // DISTINCT from the (hex) threadId. The silent-delivery guard refuses only
-    // when replyItemIds === [threadId] (the MS no-per-message-id fallback), so
-    // it must NOT block a valid Gmail reply. Guards against a provider-specific
-    // regression where Gmail sends get wrongly refused or sent without threading.
-    const tmp = mkdtempSync(join(tmpdir(), "sh-cli-draft-"));
-    const prevCfg = process.env.SUPERHUMAN_CLI_CONFIG_DIR;
-    process.env.SUPERHUMAN_CLI_CONFIG_DIR = tmp;
-    try {
-      const draftId = "draft00gmailrep";
-      const meta = {
-        draftId,
-        threadId: "19e944aeb93de925", // Gmail thread id (hex)
-        to: ["Nadya Malenko <malenko@bc.edu>"],
-        subject: "Re: paper",
-        htmlBody: "<p>Thanks!</p>",
-        inReplyTo: "<CABc123@mail.gmail.com>",
-        inReplyToItemId: "19e951ed105d2b06", // Gmail message id, != threadId
-        references: ["<CABc000@mail.gmail.com>"],
-        createdAt: new Date().toISOString(),
-        replyItemIds: ["19e951ed105d2b06"],
-      };
-      writeFileSync(join(tmp, "draft-cache.json"), JSON.stringify({ [draftId]: meta }));
-
-      const { calls, getSendBody } = setupCapturingMockFetch();
-      const provider = new SuperhumanProvider(sampleToken);
-
-      const result = await sendDraftByIdViaProvider(provider, draftId);
-
-      expect(result.success).toBe(true);
-      expect(calls.find((c) => c.includes("messages/send"))).toBeDefined();
-
-      const om = getSendBody()?.outgoing_message;
-      expect(om).toBeTruthy();
-      expect(om.thread_id).toBe("19e944aeb93de925");
-      expect(om.to).toEqual([{ email: "malenko@bc.edu", name: "Nadya Malenko" }]);
-      expect(om.in_reply_to).toBe("19e951ed105d2b06");
-      // Real per-message id + draft id — the guard let it through (threadId not appended).
-      expect(om.current_message_ids).toEqual(["19e951ed105d2b06", draftId]);
-    } finally {
-      if (prevCfg === undefined) delete process.env.SUPERHUMAN_CLI_CONFIG_DIR;
-      else process.env.SUPERHUMAN_CLI_CONFIG_DIR = prevCfg;
-      rmSync(tmp, { recursive: true, force: true });
-    }
-  });
-
-  test("sendDraftByIdViaProvider refuses when no cached metadata exists (no blind empty send)", async () => {
-    const tmp = mkdtempSync(join(tmpdir(), "sh-cli-draft-"));
-    const prevCfg = process.env.SUPERHUMAN_CLI_CONFIG_DIR;
-    process.env.SUPERHUMAN_CLI_CONFIG_DIR = tmp; // empty cache dir
-    try {
-      const { calls } = setupCapturingMockFetch();
-      const provider = new SuperhumanProvider(sampleToken);
-
-      const result = await sendDraftByIdViaProvider(provider, "draft00missing");
-
-      expect(result.success).toBe(false);
-      expect(result.error).toContain("No cached metadata");
-      // Must NOT have hit the send endpoint.
-      expect(calls.find((c) => c.includes("messages/send"))).toBeUndefined();
-    } finally {
-      if (prevCfg === undefined) delete process.env.SUPERHUMAN_CLI_CONFIG_DIR;
-      else process.env.SUPERHUMAN_CLI_CONFIG_DIR = prevCfg;
-      rmSync(tmp, { recursive: true, force: true });
-    }
-  });
-
-  test("sendDraftByIdViaProvider refuses a reply whose only thread id is the conversation id", async () => {
-    const tmp = mkdtempSync(join(tmpdir(), "sh-cli-draft-"));
-    const prevCfg = process.env.SUPERHUMAN_CLI_CONFIG_DIR;
-    process.env.SUPERHUMAN_CLI_CONFIG_DIR = tmp;
-    try {
-      const draftId = "draft00guard";
-      writeFileSync(
-        join(tmp, "draft-cache.json"),
-        JSON.stringify({
-          [draftId]: {
-            draftId,
-            threadId: "CONV==",
-            to: ["a@b.com"],
-            subject: "Re: x",
-            htmlBody: "<p>hi</p>",
-            createdAt: new Date().toISOString(),
-            replyItemIds: ["CONV=="], // only the conversation id → would fail silently
-          },
-        })
-      );
-      const { calls } = setupCapturingMockFetch();
-      const provider = new SuperhumanProvider(sampleToken);
-
-      const result = await sendDraftByIdViaProvider(provider, draftId);
-
-      expect(result.success).toBe(false);
-      expect(result.error).toContain("Refusing to send");
-      expect(calls.find((c) => c.includes("messages/send"))).toBeUndefined();
-    } finally {
-      if (prevCfg === undefined) delete process.env.SUPERHUMAN_CLI_CONFIG_DIR;
-      else process.env.SUPERHUMAN_CLI_CONFIG_DIR = prevCfg;
-      rmSync(tmp, { recursive: true, force: true });
-    }
-  });
 });
 
 describe("reply.ts with SuperhumanProvider", () => {
@@ -521,5 +320,122 @@ describe("reply.ts with SuperhumanProvider", () => {
     // Should read thread, create draft, AND send
     const sendCall = calls.find((c) => c.includes("messages/send"));
     expect(sendCall).toBeDefined();
+  });
+});
+
+describe("buildSendDraftOptions", () => {
+  const att: SuperhumanAttachment = {
+    uuid: "uuid-1",
+    name: "post.docx",
+    type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    inline: false,
+    downloadUrl: "https://media.superhuman.com/x",
+    cid: "cid-1",
+    threadId: "AAQkThreadRealId==",
+    messageId: "draft00abc123",
+    size: 1234,
+  };
+  const to: Recipient[] = [{ email: "rh2804@columbia.edu", name: "Reynolds W. Holding" }];
+
+  test("reply: carries real threadId, recipients, attachment, and current_message_ids = [...replyItemIds, draftId]", () => {
+    const r = buildSendDraftOptions({
+      draftId: "draft00abc123",
+      threadId: "AAQkThreadRealId==",
+      to,
+      subject: "Re: Mirror Voting",
+      htmlBody: "<p>Hi Ren,</p>",
+      inReplyTo: "<orig@mail.gmail.com>",
+      inReplyToItemId: "AAkItem3",
+      references: ["<r1@x.com>"],
+      replyItemIds: ["AAkItem1", "AAkItem2", "AAkItem3"],
+      attachments: [att],
+      delay: 20,
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    const o = r.options;
+    // Real thread id — NOT the draft id (the original bug used draftId here).
+    expect(o.threadId).toBe("AAQkThreadRealId==");
+    expect(o.to).toEqual(to);
+    expect(o.subject).toBe("Re: Mirror Voting");
+    expect(o.htmlBody).toBe("<p>Hi Ren,</p>");
+    expect(o.inReplyToItemId).toBe("AAkItem3");
+    // The silent-failure fix: prior thread ids + this draft.
+    expect(o.currentMessageIds).toEqual(["AAkItem1", "AAkItem2", "AAkItem3", "draft00abc123"]);
+    expect(o.attachments).toEqual([att]);
+    expect(o.delay).toBe(20);
+  });
+
+  test("Gmail reply: per-message id distinct from threadId is NOT blocked by the guard", () => {
+    // Regression: a Gmail reply's replyItemIds are real per-message ids, distinct
+    // from the (hex) threadId, so the guard must let it through.
+    const r = buildSendDraftOptions({
+      draftId: "draft00gmailrep",
+      threadId: "19e944aeb93de925",
+      to: [{ email: "malenko@bc.edu", name: "Nadya Malenko" }],
+      subject: "Re: paper",
+      htmlBody: "<p>Thanks!</p>",
+      inReplyToItemId: "19e951ed105d2b06",
+      replyItemIds: ["19e951ed105d2b06"],
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.options.currentMessageIds).toEqual(["19e951ed105d2b06", "draft00gmailrep"]);
+  });
+
+  test("compose (no replyItemIds): current_message_ids is omitted", () => {
+    const r = buildSendDraftOptions({
+      draftId: "draft00compose",
+      threadId: "draft00compose",
+      to,
+      subject: "Hello",
+      htmlBody: "<p>hi</p>",
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.options.currentMessageIds).toBeUndefined();
+  });
+
+  test("refuses an empty-recipient send (would 200 then silently never deliver)", () => {
+    const r = buildSendDraftOptions({
+      draftId: "draft00empty",
+      threadId: "T==",
+      to: [],
+      subject: "x",
+      htmlBody: "<p>x</p>",
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error).toContain("recipients");
+  });
+
+  test("refuses a reply whose only thread message id is the conversation id", () => {
+    const r = buildSendDraftOptions({
+      draftId: "draft00guard",
+      threadId: "CONV==",
+      to: [{ email: "a@b.com" }],
+      subject: "Re: x",
+      htmlBody: "<p>hi</p>",
+      replyItemIds: ["CONV=="], // == threadId → MS no-per-message-id fallback
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error).toContain("Refusing to send");
+  });
+
+  test("empty cc/bcc arrays become undefined (not []), non-empty pass through", () => {
+    const r = buildSendDraftOptions({
+      draftId: "draft00cc",
+      threadId: "T==",
+      to,
+      cc: [],
+      bcc: [{ email: "boss@x.com" }],
+      subject: "x",
+      htmlBody: "<p>x</p>",
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.options.cc).toBeUndefined();
+    expect(r.options.bcc).toEqual([{ email: "boss@x.com" }]);
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -45,7 +45,7 @@ import {
   type UpdateEventInput,
 } from "./calendar";
 import { sendEmailViaProvider, createDraftViaProvider, updateDraftViaProvider, deleteDraftViaProvider } from "./send-api";
-import { createDraftWithUserInfo, getUserInfo, getUserInfoFromCache, sendDraftSuperhuman, fetchGmailMessageHtml, buildForwardBody, updateDraftWithUserInfo, deleteDraftWithUserInfo, uploadAttachmentSuperhuman, type Recipient, type UserInfo, type SuperhumanAttachment } from "./draft-api";
+import { createDraftWithUserInfo, getUserInfo, getUserInfoFromCache, sendDraftSuperhuman, buildSendDraftOptions, fetchGmailMessageHtml, buildForwardBody, updateDraftWithUserInfo, deleteDraftWithUserInfo, uploadAttachmentSuperhuman, type Recipient, type UserInfo, type SuperhumanAttachment } from "./draft-api";
 import { searchContacts, resolveRecipient, type Contact } from "./contacts";
 import { listSnippets, findSnippet, applyVars, parseVars } from "./snippets";
 import {
@@ -234,7 +234,7 @@ ${colors.bold}COMMANDS${colors.reset}
   ${colors.cyan}forward${colors.reset} <id>        Forward an email thread
   ${colors.cyan}archive${colors.reset} <id>        Archive email thread(s)
   ${colors.cyan}delete${colors.reset} <id>         Delete (trash) email thread(s)
-  ${colors.cyan}send${colors.reset}                Compose and send, or send an existing draft
+  ${colors.cyan}send${colors.reset}                Compose and send a new email (to send a saved draft, use 'draft send')
   ${colors.cyan}ai${colors.reset} <query>          Ask AI to search, compose, or answer questions
   ${colors.cyan}ai${colors.reset} <id> <query>     Ask AI about a specific email thread
   ${colors.cyan}status${colors.reset}              Check Superhuman connection status
@@ -265,7 +265,6 @@ ${colors.bold}OPTIONS${colors.reset}
   --vars <pairs>     Template variable substitution: "key1=val1,key2=val2" (for snippet use)
   --provider <type>  Draft API: "superhuman" (default), "gmail", or "outlook"
   --native           Use native Superhuman API for draft update (auto-detected for draft00... IDs)
-  --draft <id>       Draft ID to send (for send command)
   --thread <id>      Thread ID for reply/forward drafts (for draft send)
   --delay <seconds>  Delay before sending in seconds (for draft send, default: 20)
   --label <name|id>  Label name or ID (for label add/remove, or inbox filter; repeatable)
@@ -412,7 +411,7 @@ ${colors.bold}EXAMPLES${colors.reset}
   superhuman send --to user@example.com --subject "Quick note" --body "FYI"
 
   ${colors.dim}# Send an existing draft by ID${colors.reset}
-  superhuman send --draft <draft-id>
+  superhuman draft send <draft-id>
 
 ${colors.bold}REQUIREMENTS${colors.reset}
   Superhuman must be running with remote debugging enabled:
@@ -453,8 +452,6 @@ interface CliOptions {
   send: boolean; // send immediately instead of saving as draft
   // draft update option
   updateDraftId: string; // draft ID to update (for draft command)
-  // send draft option
-  sendDraftId: string; // draft ID to send (for send command)
   // send-draft command options
   sendDraftDraftId: string; // draft ID for send-draft command
   sendDraftThreadId: string; // thread ID for reply/forward drafts (optional)
@@ -530,7 +527,6 @@ function parseArgs(args: string[]): CliOptions {
     accountArg: "",
     send: false,
     updateDraftId: "",
-    sendDraftId: "",
     sendDraftDraftId: "",
     sendDraftThreadId: "",
     sendDraftDelay: 20,
@@ -657,10 +653,6 @@ function parseArgs(args: string[]): CliOptions {
           break;
         case "update":
           options.updateDraftId = unescapeString(value);
-          i += inc;
-          break;
-        case "draft":
-          options.sendDraftId = unescapeString(value);
           i += inc;
           break;
         case "label":
@@ -1532,27 +1524,8 @@ async function cmdSendDraft(options: CliOptions) {
   // alias of SuperhumanAttachment, so the cached entries are used directly.
   const draftAttachments: SuperhumanAttachment[] = cachedMeta?.attachments ?? [];
 
-  // Guard: a reply whose only cached message id is the conversation/thread id was
-  // built from the MS-Graph/no-cache fallback and would be silently dropped by the
-  // backend (it returns 200 but never delivers). Refuse rather than send blind.
-  const replyIds = cachedMeta?.replyItemIds ?? [];
-  if (replyIds.length === 1 && replyIds[0] === resolvedThreadId) {
-    error(
-      "Refusing to send: this draft's thread message ids aren't available locally, so " +
-      "the reply would be accepted by the server but silently NOT delivered. Open the " +
-      "thread in the Superhuman app to sync it, recreate the reply, then retry."
-    );
-    process.exit(1);
-  }
-
-  if (cachedMeta) {
-    const attachNote = draftAttachments.length > 0 ? ` with ${draftAttachments.length} attachment(s)` : "";
-    info(`Sending draft ${draftId.slice(-15)}${attachNote} to ${resolvedTo.join(", ")}...`);
-  } else {
-    info(`Sending draft ${draftId.slice(-15)}...`);
-  }
-
-  const result = await sendDraftSuperhuman(userInfo, {
+  // Assemble the payload (and apply the silent-delivery guard) in one place.
+  const build = buildSendDraftOptions({
     draftId,
     threadId: resolvedThreadId,
     to: toRecipients,
@@ -1563,14 +1536,23 @@ async function cmdSendDraft(options: CliOptions) {
     inReplyTo: cachedMeta?.inReplyTo,
     inReplyToItemId: cachedMeta?.inReplyToItemId,
     references: cachedMeta?.references,
-    // Replies need the prior thread message ids in current_message_ids (+ this
-    // draft) or the MS-account send fails silently. Compose drafts have none.
-    currentMessageIds: cachedMeta?.replyItemIds && cachedMeta.replyItemIds.length > 0
-      ? [...cachedMeta.replyItemIds, draftId]
-      : undefined,
-    delay: options.sendDraftDelay,
+    replyItemIds: cachedMeta?.replyItemIds,
     attachments: draftAttachments.length > 0 ? draftAttachments : undefined,
+    delay: options.sendDraftDelay,
   });
+  if (!build.ok) {
+    error(build.error);
+    process.exit(1);
+  }
+
+  if (cachedMeta) {
+    const attachNote = draftAttachments.length > 0 ? ` with ${draftAttachments.length} attachment(s)` : "";
+    info(`Sending draft ${draftId.slice(-15)}${attachNote} to ${resolvedTo.join(", ")}...`);
+  } else {
+    info(`Sending draft ${draftId.slice(-15)}...`);
+  }
+
+  const result = await sendDraftSuperhuman(userInfo, build.options);
 
   if (result.success) {
     // The /messages/send 200 means Superhuman ACCEPTED the message into its
@@ -1674,19 +1656,8 @@ async function cmdListDrafts(options: CliOptions) {
 }
 
 async function cmdSend(options: CliOptions) {
-  // If sending an existing draft by ID, `send --draft <id>` is an alias for
-  // `draft send <id>`. Delegate so both paths share one implementation: the
-  // cached-metadata send (recipients/body/threading/attachments + the silent-
-  // -delivery-failure guard + accurate "queued, not delivered" messaging).
-  // The old inline path sent an empty outgoing_message (to:[], body:""), which
-  // the backend accepted with 200 but never delivered.
-  if (options.sendDraftId) {
-    options.sendDraftDraftId = options.sendDraftId;
-    await cmdSendDraft(options);
-    return;
-  }
-
-  // Composing and sending a new email - requires at least one recipient
+  // `send` composes and sends a new email. To send an existing saved draft,
+  // use `draft send <id>` (cmdSendDraft) — the single code path for that.
   requireAnyRecipient(options);
 
   const provider = await getProvider(options);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,7 +44,7 @@ import {
   type CreateEventInput,
   type UpdateEventInput,
 } from "./calendar";
-import { sendEmailViaProvider, createDraftViaProvider, updateDraftViaProvider, sendDraftByIdViaProvider, deleteDraftViaProvider } from "./send-api";
+import { sendEmailViaProvider, createDraftViaProvider, updateDraftViaProvider, deleteDraftViaProvider } from "./send-api";
 import { createDraftWithUserInfo, getUserInfo, getUserInfoFromCache, sendDraftSuperhuman, fetchGmailMessageHtml, buildForwardBody, updateDraftWithUserInfo, deleteDraftWithUserInfo, uploadAttachmentSuperhuman, type Recipient, type UserInfo, type SuperhumanAttachment } from "./draft-api";
 import { searchContacts, resolveRecipient, type Contact } from "./contacts";
 import { listSnippets, findSnippet, applyVars, parseVars } from "./snippets";
@@ -72,7 +72,7 @@ import { SuperhumanProvider } from "./superhuman-provider";
 import { DraftService, type Draft } from "./services/draft-service";
 import { SuperhumanDraftProvider } from "./providers/superhuman-draft-provider";
 
-const VERSION = "0.30.5";
+const VERSION = "0.30.6";
 const CDP_PORT = parseInt(process.env.CDP_PORT || "9252", 10);
 
 /**
@@ -1644,7 +1644,7 @@ async function cmdListDrafts(options: CliOptions) {
     }
 
     if (drafts.length === 0) {
-      log(`${colors.dim}No drafts found in ${email}.${colors.reset}`);
+      log(`${colors.dim}No drafts found in ${token.email}.${colors.reset}`);
       return;
     }
 
@@ -1674,23 +1674,15 @@ async function cmdListDrafts(options: CliOptions) {
 }
 
 async function cmdSend(options: CliOptions) {
-  // If sending an existing draft by ID
+  // If sending an existing draft by ID, `send --draft <id>` is an alias for
+  // `draft send <id>`. Delegate so both paths share one implementation: the
+  // cached-metadata send (recipients/body/threading/attachments + the silent-
+  // -delivery-failure guard + accurate "queued, not delivered" messaging).
+  // The old inline path sent an empty outgoing_message (to:[], body:""), which
+  // the backend accepted with 200 but never delivered.
   if (options.sendDraftId) {
-    const provider = await getProvider(options);
-
-    info(`Sending draft ${options.sendDraftId}...`);
-    const result = await sendDraftByIdViaProvider(provider, options.sendDraftId);
-
-    if (result.success) {
-      success("Draft sent!");
-      if (result.messageId) {
-        log(`  ${colors.dim}Message ID: ${result.messageId}${colors.reset}`);
-      }
-    } else {
-      error(`Failed to send draft: ${result.error}`);
-    }
-
-    await provider.disconnect();
+    options.sendDraftDraftId = options.sendDraftId;
+    await cmdSendDraft(options);
     return;
   }
 

--- a/src/draft-api.ts
+++ b/src/draft-api.ts
@@ -766,6 +766,82 @@ export async function uploadAttachmentSuperhuman(
   };
 }
 
+/** Inputs for assembling a send from an existing (cached) draft. */
+export interface BuildSendDraftInput {
+  draftId: string;
+  threadId: string;
+  to: Recipient[];
+  cc?: Recipient[];
+  bcc?: Recipient[];
+  subject: string;
+  htmlBody: string;
+  inReplyTo?: string;
+  inReplyToItemId?: string;
+  references?: string[];
+  /** Provider message ids of the prior thread messages (reply only). */
+  replyItemIds?: string[];
+  attachments?: SuperhumanAttachment[];
+  delay?: number;
+}
+
+export type BuildSendDraftResult =
+  | { ok: true; options: SendDraftOptions }
+  | { ok: false; error: string };
+
+/**
+ * Pure assembly of the {@link SendDraftOptions} for sending an existing draft,
+ * with the two checks that decide whether the send can actually be delivered:
+ *
+ *  - Empty recipients → refuse (the backend accepts an empty `to` with HTTP 200
+ *    then silently never delivers).
+ *  - A reply whose only thread message id is the conversation/thread id itself
+ *    (the MS-Graph/no-per-message-id fallback) → refuse: the backend accepts it
+ *    (200) but silently drops it. Open the thread in the app to sync real ids.
+ *
+ * `current_message_ids` is derived as `[...replyItemIds, draftId]` for replies
+ * (compose drafts have none). No I/O — returns a discriminated result so the
+ * caller decides how to surface a refusal. This is the single source of truth
+ * for the send-an-existing-draft payload; `cmdSendDraft` is its only caller.
+ */
+export function buildSendDraftOptions(input: BuildSendDraftInput): BuildSendDraftResult {
+  const { draftId, threadId, replyItemIds = [] } = input;
+
+  if (input.to.length === 0) {
+    return { ok: false, error: "Draft has no recipients to send to." };
+  }
+
+  if (replyItemIds.length === 1 && replyItemIds[0] === threadId) {
+    return {
+      ok: false,
+      error:
+        "Refusing to send: this draft's thread message ids aren't available locally, so " +
+        "the reply would be accepted by the server but silently NOT delivered. Open the " +
+        "thread in the Superhuman app to sync it, recreate the reply, then retry.",
+    };
+  }
+
+  return {
+    ok: true,
+    options: {
+      draftId,
+      threadId,
+      to: input.to,
+      cc: input.cc && input.cc.length > 0 ? input.cc : undefined,
+      bcc: input.bcc && input.bcc.length > 0 ? input.bcc : undefined,
+      subject: input.subject,
+      htmlBody: input.htmlBody,
+      inReplyTo: input.inReplyTo,
+      inReplyToItemId: input.inReplyToItemId,
+      references: input.references,
+      // Replies need the prior thread message ids in current_message_ids (+ this
+      // draft) or the MS-account send fails silently. Compose drafts have none.
+      currentMessageIds: replyItemIds.length > 0 ? [...replyItemIds, draftId] : undefined,
+      attachments: input.attachments && input.attachments.length > 0 ? input.attachments : undefined,
+      delay: input.delay,
+    },
+  };
+}
+
 /**
  * Send a draft via Superhuman's native /messages/send endpoint.
  *

--- a/src/send-api.ts
+++ b/src/send-api.ts
@@ -14,20 +14,6 @@ import {
   type Recipient,
 } from "./draft-api";
 import { textToHtml } from "./superhuman-api.js";
-import { loadDraftMeta } from "./draft-cache";
-
-/**
- * Parse a "Name <email>" or bare "email" string into a Recipient.
- */
-function parseRecipientString(s: string): Recipient {
-  const m = s.match(/^\s*(.*?)\s*<([^>]+)>\s*$/);
-  if (m) {
-    const email = (m[2] ?? "").trim();
-    const name = (m[1] ?? "").replace(/^"|"$/g, "").trim();
-    return name ? { email, name } : { email };
-  }
-  return { email: s.trim() };
-}
 
 /**
  * Options for sending an email
@@ -244,79 +230,6 @@ export async function updateDraftViaProvider(
       body: htmlBody,
     });
     return { success: ok, draftId };
-  }
-
-  throw new Error(
-    "SuperhumanProvider required. Run 'superhuman account auth' to authenticate."
-  );
-}
-
-/**
- * Send a draft by ID using a ConnectionProvider.
- * Routes through SuperhumanProvider (direct backend) or MCP.
- */
-export async function sendDraftByIdViaProvider(
-  provider: ConnectionProvider,
-  draftId: string
-): Promise<SendResult> {
-  if (provider instanceof SuperhumanProvider) {
-    const userInfo = await userInfoFromProvider(provider);
-
-    // Load the metadata persisted when the draft was created. It holds the real
-    // threadId, recipients, subject, body, reply-threading ids and attachments —
-    // everything /messages/send needs to actually deliver. The previous
-    // behavior (to:[], subject:"", htmlBody:"", threadId=draftId) made the
-    // backend return 200 but silently never deliver: the outgoing_message had no
-    // recipients and pointed at a thread id that doesn't exist.
-    const meta = loadDraftMeta(draftId);
-    if (!meta) {
-      return {
-        success: false,
-        error:
-          `No cached metadata for ${draftId}; cannot reconstruct the message to send. ` +
-          `Recreate it with the CLI (draft create / reply / forward) before sending.`,
-      };
-    }
-
-    // Guard: a reply whose only cached thread message id is the conversation /
-    // thread id was built from the MS-Graph/no-cache fallback and would be
-    // accepted by the backend (200) but silently NOT delivered. Refuse rather
-    // than send blind. (Mirrors cmdSendDraft.)
-    const replyIds = meta.replyItemIds ?? [];
-    if (replyIds.length === 1 && replyIds[0] === meta.threadId) {
-      return {
-        success: false,
-        error:
-          "Refusing to send: this draft's thread message ids aren't available " +
-          "locally, so the reply would be accepted by the server but silently " +
-          "NOT delivered. Open the thread in the Superhuman app to sync it, " +
-          "recreate the reply, then retry.",
-      };
-    }
-
-    const attachments =
-      meta.attachments && meta.attachments.length > 0 ? meta.attachments : undefined;
-
-    const sendResult = await sendDraftSuperhuman(userInfo, {
-      draftId,
-      threadId: meta.threadId,
-      to: meta.to.map(parseRecipientString),
-      cc: meta.cc && meta.cc.length > 0 ? meta.cc.map(parseRecipientString) : undefined,
-      bcc: meta.bcc && meta.bcc.length > 0 ? meta.bcc.map(parseRecipientString) : undefined,
-      subject: meta.subject,
-      htmlBody: meta.htmlBody,
-      inReplyTo: meta.inReplyTo,
-      inReplyToItemId: meta.inReplyToItemId,
-      references: meta.references,
-      // Replies need the prior thread message ids in current_message_ids (+ this
-      // draft) or the MS-account send fails silently. Compose drafts have none.
-      currentMessageIds: replyIds.length > 0 ? [...replyIds, draftId] : undefined,
-      attachments,
-    });
-    if (!sendResult.success) {
-      return { success: false, error: sendResult.error };
-    }
-    return { success: true, messageId: draftId };
   }
 
   throw new Error(

--- a/src/send-api.ts
+++ b/src/send-api.ts
@@ -14,6 +14,20 @@ import {
   type Recipient,
 } from "./draft-api";
 import { textToHtml } from "./superhuman-api.js";
+import { loadDraftMeta } from "./draft-cache";
+
+/**
+ * Parse a "Name <email>" or bare "email" string into a Recipient.
+ */
+function parseRecipientString(s: string): Recipient {
+  const m = s.match(/^\s*(.*?)\s*<([^>]+)>\s*$/);
+  if (m) {
+    const email = (m[2] ?? "").trim();
+    const name = (m[1] ?? "").replace(/^"|"$/g, "").trim();
+    return name ? { email, name } : { email };
+  }
+  return { email: s.trim() };
+}
 
 /**
  * Options for sending an email
@@ -247,14 +261,57 @@ export async function sendDraftByIdViaProvider(
 ): Promise<SendResult> {
   if (provider instanceof SuperhumanProvider) {
     const userInfo = await userInfoFromProvider(provider);
-    // Minimal send — draft already has recipients/subject/body persisted.
-    // We need at least the draftId and threadId; use draftId as threadId.
+
+    // Load the metadata persisted when the draft was created. It holds the real
+    // threadId, recipients, subject, body, reply-threading ids and attachments —
+    // everything /messages/send needs to actually deliver. The previous
+    // behavior (to:[], subject:"", htmlBody:"", threadId=draftId) made the
+    // backend return 200 but silently never deliver: the outgoing_message had no
+    // recipients and pointed at a thread id that doesn't exist.
+    const meta = loadDraftMeta(draftId);
+    if (!meta) {
+      return {
+        success: false,
+        error:
+          `No cached metadata for ${draftId}; cannot reconstruct the message to send. ` +
+          `Recreate it with the CLI (draft create / reply / forward) before sending.`,
+      };
+    }
+
+    // Guard: a reply whose only cached thread message id is the conversation /
+    // thread id was built from the MS-Graph/no-cache fallback and would be
+    // accepted by the backend (200) but silently NOT delivered. Refuse rather
+    // than send blind. (Mirrors cmdSendDraft.)
+    const replyIds = meta.replyItemIds ?? [];
+    if (replyIds.length === 1 && replyIds[0] === meta.threadId) {
+      return {
+        success: false,
+        error:
+          "Refusing to send: this draft's thread message ids aren't available " +
+          "locally, so the reply would be accepted by the server but silently " +
+          "NOT delivered. Open the thread in the Superhuman app to sync it, " +
+          "recreate the reply, then retry.",
+      };
+    }
+
+    const attachments =
+      meta.attachments && meta.attachments.length > 0 ? meta.attachments : undefined;
+
     const sendResult = await sendDraftSuperhuman(userInfo, {
       draftId,
-      threadId: draftId,
-      to: [],
-      subject: "",
-      htmlBody: "",
+      threadId: meta.threadId,
+      to: meta.to.map(parseRecipientString),
+      cc: meta.cc && meta.cc.length > 0 ? meta.cc.map(parseRecipientString) : undefined,
+      bcc: meta.bcc && meta.bcc.length > 0 ? meta.bcc.map(parseRecipientString) : undefined,
+      subject: meta.subject,
+      htmlBody: meta.htmlBody,
+      inReplyTo: meta.inReplyTo,
+      inReplyToItemId: meta.inReplyToItemId,
+      references: meta.references,
+      // Replies need the prior thread message ids in current_message_ids (+ this
+      // draft) or the MS-account send fails silently. Compose drafts have none.
+      currentMessageIds: replyIds.length > 0 ? [...replyIds, draftId] : undefined,
+      attachments,
     });
     if (!sendResult.success) {
       return { success: false, error: sendResult.error };


### PR DESCRIPTION
Fixes two bugs that made sending a saved draft unreliable on Microsoft accounts, plus dead-code/footgun cleanup.

- `send --draft`/`draft send <id>` posted an empty `outgoing_message` (`to:[]`, empty body, `threadId=draftId`) → backend 200 but silent non-delivery. Now loads cached draft metadata and sends the full payload (recipients, body, threading ids, `current_message_ids`, attachments).
- `draft list` crashed with `email is not defined` on empty mailboxes (`${email}` → `${token.email}`).
- Deleted the dead `sendDraftByIdViaProvider` + the redundant `send --draft` alias; extracted one tested `buildSendDraftOptions` helper (single send-a-draft path: `draft send <id>`).
- Added a Gmail reply regression test (guard must not block real per-message ids).

bun test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)