### PR TITLE
fix: sync --check works offline (on-disk account enumeration)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superhuman-cli",
-  "version": "0.38.2",
+  "version": "0.38.3",
   "module": "src/index.ts",
   "type": "module",
   "private": true,

--- a/src/__tests__/inbox-backend.test.ts
+++ b/src/__tests__/inbox-backend.test.ts
@@ -443,6 +443,10 @@ describe("inbox without portal (no CDP connection)", () => {
 // ---------------------------------------------------------------------------
 
 import * as sqliteSearch from "../sqlite-search";
+// Snapshot REAL exports before any mock.module runs — restoring to the live
+// `sqliteSearch` namespace is self-defeating (mock.module mutates its bindings),
+// so a stable snapshot is what prevents cross-file mock leakage.
+const REAL_SQLITE = { ...sqliteSearch };
 
 /** Build a fake ListInboxRow[] with parsed JSON thread data */
 function makeSQLiteRows(count: number, opts?: { allUnread?: boolean }): sqliteSearch.ListInboxRow[] {
@@ -484,7 +488,7 @@ describe("listInbox SQLite-first path", () => {
     expect(threads[0].subject).toBe("SQLite Subject 0");
     expect(threads[0].from.email).toBe("sqlite0@example.com");
 
-    mock.module("../sqlite-search", () => sqliteSearch);
+    mock.module("../sqlite-search", () => REAL_SQLITE);
   });
 
   test("falls back to portal when SQLite returns null", async () => {
@@ -502,7 +506,7 @@ describe("listInbox SQLite-first path", () => {
     expect(portalMock).toHaveBeenCalledTimes(1);
     expect(threads).toHaveLength(2);
 
-    mock.module("../sqlite-search", () => sqliteSearch);
+    mock.module("../sqlite-search", () => REAL_SQLITE);
   });
 
   test("SQLite path respects unreadOnly filter", async () => {
@@ -521,7 +525,7 @@ describe("listInbox SQLite-first path", () => {
     expect(threads).toHaveLength(1);
     expect(threads[0].labelIds).toContain("UNREAD");
 
-    mock.module("../sqlite-search", () => sqliteSearch);
+    mock.module("../sqlite-search", () => REAL_SQLITE);
   });
 
   test("SQLite path respects splitInbox option (passes correct listId)", async () => {
@@ -540,6 +544,6 @@ describe("listInbox SQLite-first path", () => {
     const [emailArg, listIdArg] = dbMock.mock.calls[0] as [string, string, number];
     expect(listIdArg).toBe("SH_IMPORTANT");
 
-    mock.module("../sqlite-search", () => sqliteSearch);
+    mock.module("../sqlite-search", () => REAL_SQLITE);
   });
 });

--- a/src/__tests__/labels-list.test.ts
+++ b/src/__tests__/labels-list.test.ts
@@ -8,6 +8,10 @@ import type { SuperhumanTokenInfo } from "../superhuman-provider";
 import type { SuperhumanConnection } from "../superhuman-api";
 import { listLabels, listStarred } from "../labels";
 import * as sqliteSearch from "../sqlite-search";
+// Snapshot REAL exports before any mock.module runs — restoring to the live
+// `sqliteSearch` namespace is self-defeating (mock.module mutates its bindings),
+// so a stable snapshot is what prevents cross-file mock leakage.
+const REAL_SQLITE = { ...sqliteSearch };
 
 const sampleToken: SuperhumanTokenInfo = {
   token: "test-jwt-token",
@@ -98,12 +102,12 @@ describe("listStarred", () => {
   // override explicitly before each test here.
   beforeEach(() => {
     mock.module("../sqlite-search", () => ({
-      ...sqliteSearch,
+      ...REAL_SQLITE,
       listInboxFromDB: () => null,
     }));
   });
   afterAll(() => {
-    mock.module("../sqlite-search", () => sqliteSearch);
+    mock.module("../sqlite-search", () => REAL_SQLITE);
   });
 
   test("calls portalInvoke with STARRED listId", async () => {

--- a/src/__tests__/read-backend.test.ts
+++ b/src/__tests__/read-backend.test.ts
@@ -9,6 +9,13 @@ import { SuperhumanProvider } from "../superhuman-provider";
 import type { SuperhumanTokenInfo } from "../superhuman-provider";
 import { readThread, type ThreadMessage } from "../read";
 import * as sqliteSearch from "../sqlite-search";
+// Snapshot the REAL exports once, before any mock.module runs. Restoring to the
+// live `sqliteSearch` namespace is self-defeating: mock.module mutates that
+// namespace's bindings, so `() => sqliteSearch` re-installs the *mock*. A plain
+// snapshot captured here holds the real function refs and can't be polluted —
+// preventing this file's readThreadFromDB fake from leaking into later files
+// (e.g. thread-mutations, which relies on the real disk-lookup fallback).
+const REAL_SQLITE = { ...sqliteSearch };
 
 const sampleToken: SuperhumanTokenInfo = {
   token: "test-jwt-token",
@@ -107,7 +114,7 @@ describe("readThread with SuperhumanProvider", () => {
   beforeEach(() => {
     originalFetch = globalThis.fetch;
     // Ensure sqlite-search is always restored to real module before each test
-    mock.module("../sqlite-search", () => sqliteSearch);
+    mock.module("../sqlite-search", () => REAL_SQLITE);
   });
 
   afterEach(() => {
@@ -234,6 +241,11 @@ describe("readThread with SuperhumanProvider", () => {
     (provider as any).conn = {};
     provider.portalInvoke = mockPortalInvoke as any;
 
+    // Portal returns no matching thread → readThreadSuperhuman falls through to
+    // the backend. Mock an empty backend response so the test stays hermetic
+    // (no real fetch to mail.superhuman.com in offline/CI).
+    setupMockFetch({ threadList: [] });
+
     const messages = await readThread(provider, "nonexistent_id");
     expect(messages).toEqual([]);
   });
@@ -344,6 +356,10 @@ describe("readThread with SuperhumanProvider", () => {
     const mockPortalInvoke = mock(() => Promise.resolve({ threads: [] }));
     (provider as any).conn = {};
     provider.portalInvoke = mockPortalInvoke as any;
+
+    // Empty portal result → falls through to the backend; mock an empty backend
+    // response so the test never makes a real network call in offline/CI.
+    setupMockFetch({ threadList: [] });
 
     const messages = await readThread(provider, "thread_empty");
     expect(messages).toEqual([]);
@@ -509,13 +525,13 @@ describe("readThread with SuperhumanProvider", () => {
 
     function mockSQLite(readThreadFromDB: (...args: any[]) => any) {
       mock.module("../sqlite-search", () => ({
-        ...sqliteSearch,
+        ...REAL_SQLITE,
         readThreadFromDB,
       }));
     }
 
     afterEach(() => {
-      mock.module("../sqlite-search", () => sqliteSearch);
+      mock.module("../sqlite-search", () => REAL_SQLITE);
     });
 
     test("readThread uses SQLite when DB has thread", async () => {

--- a/src/__tests__/sync-check-offline.test.ts
+++ b/src/__tests__/sync-check-offline.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Regression tests for the CDP-free `sync --check` path.
+ *
+ * Bug: `superhuman sync --check` is documented (and used by the morning-briefing
+ * freshness gate) as a pure on-disk cache-staleness report needing no CDP. But
+ * `cmdSync` enumerated accounts only via `listSyncableAccounts()` (a live
+ * background_page read over CDP) and hard-exited with "No linked accounts found"
+ * when the app wasn't running with the debug port — before ever reaching the
+ * `--check` branch. So the report was impossible exactly when it mattered most
+ * (app closed). Compounding it, the on-disk enumerator `listLocalAccounts()`
+ * scanned browser roots only, returning [] on a desktop-app install.
+ *
+ * These are source-level guarantees (the enumerators read real homedir OPFS
+ * roots at call time, so a functional test would need un-injectable filesystem
+ * fixtures — matching the repo convention in attachment-download.test.ts of
+ * asserting the wiring at the source level).
+ */
+import { test, expect, describe } from "bun:test";
+
+const cliSrc = await Bun.file(new URL("../cli.ts", import.meta.url)).text();
+const sqliteSrc = await Bun.file(new URL("../sqlite-search.ts", import.meta.url)).text();
+
+describe("sync --check offline enumeration", () => {
+  test("cmdSync falls back to on-disk enumeration when the app is unreachable", () => {
+    // Locate the sync command body.
+    const start = cliSrc.indexOf("async function cmdSync(");
+    expect(start).toBeGreaterThan(-1);
+    const body = cliSrc.slice(start, start + 2500);
+
+    // Live CDP enumeration is still tried first…
+    expect(body).toContain("listSyncableAccounts(options.port)");
+    // …and falls back to the pure on-disk scan when it returns nothing.
+    expect(body).toContain("listLocalAccounts()");
+  });
+
+  test("cmdSync no longer hard-exits before the --check branch", () => {
+    const start = cliSrc.indexOf("async function cmdSync(");
+    const checkIdx = cliSrc.indexOf("if (options.check)", start);
+    const exitIdx = cliSrc.indexOf("process.exit(1)", start);
+    expect(checkIdx).toBeGreaterThan(-1);
+    expect(exitIdx).toBeGreaterThan(-1);
+    // The remaining hard-exit must only fire AFTER the disk fallback has also
+    // come up empty — its guard mentions the on-disk cache, and the --check
+    // branch is still reachable (exit is guarded by targets.length === 0).
+    const exitLine = cliSrc.slice(exitIdx - 320, exitIdx);
+    expect(exitLine).toContain("targets.length === 0");
+    expect(cliSrc.slice(start, exitIdx)).toContain("cached account blobs found on disk");
+  });
+
+  test("each --check report entry carries a source (app|disk) field", () => {
+    const start = cliSrc.indexOf("if (options.check)", cliSrc.indexOf("async function cmdSync("));
+    const branch = cliSrc.slice(start, start + 700);
+    expect(branch).toContain('source: enumeratedFromDisk ? "disk" : "app"');
+  });
+});
+
+describe("listLocalAccounts desktop-over-browser precedence", () => {
+  test("scans DESKTOP_ROOTS first, not browser roots only", () => {
+    const start = sqliteSrc.indexOf("export function listLocalAccounts(");
+    expect(start).toBeGreaterThan(-1);
+    const body = sqliteSrc.slice(start, start + 700);
+    // Must consult the authoritative desktop data dir…
+    expect(body).toContain("DESKTOP_ROOTS.filter");
+    // …and consult browser roots only as the no-desktop fallback (same pattern
+    // as findOPFSBlob), never browser-roots-only as before.
+    expect(body).toContain("desktopRoots.length > 0 ? desktopRoots : BROWSER_ROOTS");
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,6 +25,7 @@ import {
 import { listInbox, searchInbox, streamListInbox, streamSearchInbox } from "./inbox";
 import type { InboxThread } from "./inbox";
 import { searchDirect, listLocalAccounts, lookupThreadInfoById, getThreadBodiesFromDB, resolveContactsByEmail } from "./sqlite-search";
+// listLocalAccounts doubles as the CDP-free account enumerator for `sync`.
 import { extractLatestMessage } from "./quote-strip";
 import { saveDraftMeta, loadDraftMeta, deleteDraftMeta } from "./draft-cache";
 import { listAccounts, listAccountsChrome, switchAccount, type Account } from "./accounts";
@@ -74,7 +75,7 @@ import { SuperhumanProvider } from "./superhuman-provider";
 import { DraftService, type Draft } from "./services/draft-service";
 import { SuperhumanDraftProvider } from "./providers/superhuman-draft-provider";
 
-const VERSION = "0.38.2";
+const VERSION = "0.38.3";
 const CDP_PORT = parseInt(process.env.CDP_PORT || "9252", 10);
 
 /**
@@ -1308,25 +1309,41 @@ async function cmdSync(options: CliOptions) {
   const maxAgeMs = Math.max(0, options.syncMaxAgeMinutes) * 60_000;
   const timeoutMs = Math.max(0, options.syncTimeoutSeconds) * 1000;
 
-  const targets = options.account
+  // Prefer the live background_page enumeration (ground truth for "what's
+  // linked" this session). When the app isn't running with the debug port that
+  // returns [] — fall back to a pure on-disk scan of the OPFS caches so `sync`
+  // still works offline. This is essential for `--check`, which is a filesystem
+  // staleness report that needs no CDP at all: without the fallback it used to
+  // hard-exit with "No linked accounts found" the moment the app was closed,
+  // defeating its own purpose (and the morning-briefing freshness gate).
+  let targets = options.account
     ? [options.account]
     : await listSyncableAccounts(options.port);
+  let enumeratedFromDisk = false;
+  if (targets.length === 0 && !options.account) {
+    targets = listLocalAccounts();
+    enumeratedFromDisk = targets.length > 0;
+  }
 
-  if (targets.length === 0) {
-    if (options.account) {
-      // Fall through — ensureAccountSynced will report no-connection/no-context.
-    } else {
-      error("No linked accounts found (background_page unreachable — is Superhuman.app running with --remote-debugging-port?)");
-      process.exit(1);
-    }
+  if (targets.length === 0 && !options.account) {
+    error("No linked accounts found — none reachable via the app (is Superhuman running with --remote-debugging-port?) and no cached account blobs found on disk.");
+    process.exit(1);
   }
 
   if (options.check) {
-    const report = targets.map((email) => ({ email, freshness: getAccountFreshness(email) }));
+    const report = targets.map((email) => ({
+      email,
+      source: enumeratedFromDisk ? "disk" : "app",
+      freshness: getAccountFreshness(email),
+    }));
     if (options.json) {
+      // Backward-compatible array shape; each entry gains a `source` field.
       printJson(report);
     } else {
       log("Local cache staleness report:");
+      if (enumeratedFromDisk) {
+        log(`  ${colors.dim}(app not reachable over CDP — accounts enumerated from on-disk caches)${colors.reset}`);
+      }
       for (const r of report) log(formatFreshnessLine(r.email, r.freshness));
     }
     return;

--- a/src/sqlite-search.ts
+++ b/src/sqlite-search.ts
@@ -409,18 +409,31 @@ export async function searchDirect(options: DirectSearchOptions): Promise<Direct
 }
 
 /**
- * List all accounts that have a local Superhuman SQLite database.
+ * Enumerate every account that has a local OPFS SQLite cache on disk — a pure
+ * filesystem scan, no CDP / no running app required. This is the CDP-free
+ * counterpart to `listSyncableAccounts()` (which reads the live background_page
+ * iframes): used for cross-account fallback (contacts/attachments), for cache
+ * staleness reporting (`sync --check`), and as an account-enumeration fallback
+ * when Superhuman isn't running with the debug port.
+ *
+ * Applies the same desktop-over-browser root precedence as `findOPFSBlob`: the
+ * desktop app's data dir is authoritative and holds a blob for EVERY linked
+ * account, so browser roots are consulted ONLY when no desktop data dir exists.
+ * (Previously this scanned browser roots only, so it returned nothing on a
+ * desktop-app install — silently breaking every fallback that relies on it.)
  */
 export function listLocalAccounts(): string[] {
+  const desktopRoots = DESKTOP_ROOTS.filter((r) => existsSync(r));
+  const roots = desktopRoots.length > 0 ? desktopRoots : BROWSER_ROOTS;
+
   const accounts: string[] = [];
-  for (const root of BROWSER_ROOTS) {
+  for (const root of roots) {
     if (!existsSync(root)) continue;
-    const blobs = findBlobsInRoot(root);
-    for (const blobPath of blobs) {
+    for (const blobPath of findBlobsInRoot(root)) {
       const header = readOPFSHeader(blobPath);
       if (!header) continue;
       // Strip leading '/' and trailing '.sqlite3'
-      const email = header.replace(/^\//, "").replace(/\.sqlite3$/, "");
+      const email = header.replace(/^\//, "").replace(/\.sqlite3$/i, "");
       if (email.includes("@") && !accounts.includes(email)) {
         accounts.push(email);
       }


### PR DESCRIPTION
## Problem

`superhuman sync --check` is documented — and used by the morning-briefing freshness gate — as a **pure on-disk cache-staleness report** that needs no CDP. But `cmdSync` enumerated accounts only via `listSyncableAccounts()` (a live `background_page` read over CDP) and **hard-exited with "No linked accounts found"** when Superhuman wasn't running with the debug port, *before* ever reaching the `--check` branch.

Result: the staleness report was impossible in exactly the situation it exists for (app closed). This is what broke the morning briefing today — its documented fallback ("if sync errors, flag cache ages from `sync --check`") could never fire.

Compounding it, the on-disk enumerator `listLocalAccounts()` scanned `BROWSER_ROOTS` only, so it returned `[]` on a **desktop-app install** — silently breaking not just this fallback but the contacts/attachments cross-account fallbacks that also rely on it.

## Fix

- `listLocalAccounts()` now applies the same **desktop-over-browser root precedence** as `findOPFSBlob()` (the desktop data dir is authoritative and holds a blob for every linked account).
- `cmdSync` falls back to `listLocalAccounts()` when live CDP enumeration returns nothing, so `sync` — and especially `--check` — work with the app closed. The hard-exit now fires only when disk enumeration is *also* empty.
- `--check` reports gain a per-entry `source` (`"app"` | `"disk"`) field and a human-readable note when enumerated from disk. JSON stays a backward-compatible array.

## Verification

With Superhuman **not** running with CDP (the exact failure case):

```
$ superhuman sync --check
Local cache staleness report:
  (app not reachable over CDP — accounts enumerated from on-disk caches)
  eddyhu@gmail.com: 7747 threads, 12678 messages, newest activity 7.3 min ago
  ehu@law.virginia.edu: 2241 threads, 3347 messages, newest activity 26.6 min ago
$ echo $?
0
```

Previously this exited 1 with "No linked accounts found".

Full suite: 431 pass / 1 skip / 4 fail (the 4 failures are pre-existing MS Graph thread-mutation tests, unrelated — identical on `main`). Added `src/__tests__/sync-check-offline.test.ts` (4 tests) locking in the disk fallback and desktop-precedence guarantees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4JPhGyCWoA6bAT9M3LzR9