### PR TITLE
fix: discover the CDP endpoint — Electron app first, then Chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,13 @@ bun install
 ```
 
 > On macOS this is best done via a LaunchAgent so the app always starts with CDP
-> enabled at login — see `com.user.superhuman-cdp.plist`. The CLI also auto-probes
-> 9252 → 9250 → 9222 when neither `--port` nor `CDP_PORT` is set.
+> enabled at login — see `com.user.superhuman-cdp.plist`. When neither `--port`
+> nor `CDP_PORT` is set, the CLI probes the desktop app first, then the browser:
+> `ELECTRON_CDP_PORT` (default 9252) → `CHROME_CDP_PORT` (default 9222). They are
+> different CDP endpoints, not different tabs on one.
+>
+> `CDP_PORT` pins a single port and skips probing. 9250 (the old Chrome-tab-mode
+> default) is no longer probed — set `CHROME_CDP_PORT=9250` if you still run it.
 
 ## Building & Installing
 

--- a/scripts/cdp-substrate-gate.sh
+++ b/scripts/cdp-substrate-gate.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Mechanical substrate gates for the endpoint-discovery PRs.
+#
+# Every regression I shipped across four review rounds fell into two classes, and
+# both are mechanically detectable. LLM auditors caught them; I did not. So the
+# gate is a script, not my memory:
+#
+#   G1 DRIFT   the shared section of cdp-endpoint.ts must be byte-identical
+#              across both repos. Six drift incidents, every one from editing one
+#              file and asserting identity without running diff.
+#
+#   G2 ROLE    no target that MAIN's selectors accept may be rejected by the
+#              branch's, and no target main REJECTS may be accepted. Catches both
+#              "I broke Mac auth" (false negative) and "I widened role so account
+#              auth picks the login page" (false positive) — the two HIGHs I
+#              introduced while hardening.
+#
+#   G3 TESTS   both suites at baseline.
+#   G4 TSC     no new type errors.
+#
+# Exit 0 = substrate clean.
+set -uo pipefail
+
+MG=/home/eh/projects/morgen-cli/.claude/worktrees/endpoint-discovery
+SH=/home/eh/projects/superhuman-cli/.claude/worktrees/endpoint-discovery
+fails=0
+note() { printf '  %-6s %s\n' "$1" "$2"; }
+
+echo "── G1 drift: shared section byte-identical ──"
+sed -n '/END PRODUCT BLOCK/,$p' "$MG/src/cdp-endpoint.ts" > /tmp/g1a.ts
+sed -n '/END PRODUCT BLOCK/,$p' "$SH/src/cdp-endpoint.ts" > /tmp/g1b.ts
+if diff -q /tmp/g1a.ts /tmp/g1b.ts >/dev/null 2>&1; then
+  note PASS "identical ($(wc -l < /tmp/g1a.ts) lines)"
+else
+  note FAIL "DRIFTED — $(diff /tmp/g1a.ts /tmp/g1b.ts | grep -c '^[<>]') differing lines"
+  fails=$((fails+1))
+fi
+
+echo "── G2 role: branch selectors vs main's, on real + impostor targets ──"
+run_g2() {
+  local repo="$1" name="$2"
+  ( cd "$repo" && timeout 60 bun -e '
+    import { classifyTarget } from "./src/cdp-endpoint";
+    // [url, mustBe] — derived from what MAIN accepted, plus impostors main also rejected.
+    const cases: [string, string|null][] = JSON.parse(process.env.G2_CASES!);
+    let bad = 0;
+    for (const [url, want] of cases) {
+      const got = classifyTarget({ type: "page", url });
+      if (got !== want) { console.log(`    MISMATCH ${url}\n      got=${got} want=${want}`); bad++; }
+    }
+    process.exit(bad === 0 ? 0 : 1);
+  ' ) 2>&1
+}
+
+# morgen: main accepted morgen:// and *morgen.so*; impostors main also rejected.
+export G2_CASES='[
+  ["morgen://./app.html","electron"],
+  ["file:///opt/Morgen/resources/app.html","electron"],
+  ["https://web.morgen.so/","chrome"],
+  ["https://web.morgen.so./calendar","chrome"],
+  ["https://app.morgen.so/tasks","chrome"],
+  ["https://example.com/","null"],
+  ["https://morgen.so.evil.example/app.html","null"],
+  ["https://evil.example/morgen/app.html","null"],
+  ["chrome-extension://abc/app/app.html","null"]
+]'
+export G2_CASES=$(echo "$G2_CASES" | sed 's/"null"/null/g')
+if run_g2 "$MG" morgen; then note PASS "morgen classifier"; else note FAIL "morgen classifier"; fails=$((fails+1)); fi
+
+# superhuman: the REAL desktop scheme + the app page; role must stay mail.* only.
+export G2_CASES='[
+  ["superhuman-app://superhuman.com/background_page.html","electron"],
+  ["https://mail.superhuman.com/~backend/build/background_page.html","electron"],
+  ["https://mail.superhuman.com/e@x.com/inbox","chrome"],
+  ["https://mail.superhuman.com./inbox","chrome"],
+  ["https://superhuman.com/blog/very-long-marketing-slug","null"],
+  ["https://accounts.superhuman.com/login","null"],
+  ["https://evil.example/superhuman/background_page.html","null"],
+  ["https://mail.superhuman.com.evil.example/inbox","null"],
+  ["superhuman-app://evil.example/background_page.html","null"]
+]'
+export G2_CASES=$(echo "$G2_CASES" | sed 's/"null"/null/g')
+if run_g2 "$SH" superhuman; then note PASS "superhuman classifier"; else note FAIL "superhuman classifier"; fails=$((fails+1)); fi
+
+echo "── G3 tests at baseline ──"
+m=$(cd "$MG" && bun test 2>&1 | grep -oE '[0-9]+ fail' | head -1)
+s=$(cd "$SH" && bun test 2>&1 | grep -oE '[0-9]+ fail' | head -1)
+[ "$m" = "0 fail" ] && note PASS "morgen $m" || { note FAIL "morgen $m"; fails=$((fails+1)); }
+[ "$s" = "0 fail" ] && note PASS "superhuman $s" || { note FAIL "superhuman $s (run: account auth — E2E needs fresh tokens)"; fails=$((fails+1)); }
+
+echo "── G4 tsc vs baseline (morgen 75, superhuman 0) ──"
+mt=$(cd "$MG" && bunx tsc --noEmit --pretty false 2>&1 | grep -c 'error TS')
+st=$(cd "$SH" && bunx tsc --noEmit --pretty false 2>&1 | grep -c 'error TS')
+[ "$mt" -le 75 ] && note PASS "morgen $mt" || { note FAIL "morgen $mt > 75"; fails=$((fails+1)); }
+[ "$st" -eq 0 ] && note PASS "superhuman $st" || { note FAIL "superhuman $st > 0"; fails=$((fails+1)); }
+
+echo ""
+echo "SUBSTRATE: $([ $fails -eq 0 ] && echo CLEAN || echo "DIRTY ($fails gate(s) failing)")"
+exit $fails

--- a/scripts/cdp-substrate-gate.sh
+++ b/scripts/cdp-substrate-gate.sh
@@ -37,7 +37,33 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SH="${SUPERHUMAN_REPO:-$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null)}"
-MG="${MORGEN_REPO:-/home/eh/projects/morgen-cli/.claude/worktrees/endpoint-discovery}"
+# MG gets the same git-rev-parse-based treatment SH has, not a bare hardcoded
+# worktree literal. MORGEN_REPO always wins. Absent that, try candidates in
+# order and take the first that actually contains the branch's source file:
+#   1. the sibling morgen-cli checkout next to superhuman-cli's MAIN repo
+#      (resolved via --git-common-dir, which survives running from inside a
+#      worktree) — this is what will be correct once the feature branch
+#      merges to morgen-cli's main and the worktree below is removed.
+#   2. the feature worktree — last-resort default for local pre-merge dev;
+#      documented to stop resolving once that worktree is removed, at which
+#      point (1) should already be correct and callers should also just set
+#      MORGEN_REPO explicitly (see cdp-substrate-gate.test.sh test3).
+SH_COMMON_DIR="$(git -C "$SCRIPT_DIR" rev-parse --git-common-dir 2>/dev/null)"
+SH_MAIN_REPO="$(cd "$(dirname "$SH_COMMON_DIR")" 2>/dev/null && pwd)"
+MG_CANDIDATES=()
+if [ -n "$SH_MAIN_REPO" ]; then
+  sibling_top="$(git -C "$(dirname "$SH_MAIN_REPO")/morgen-cli" rev-parse --show-toplevel 2>/dev/null)"
+  [ -n "$sibling_top" ] && MG_CANDIDATES+=("$sibling_top")
+fi
+MG_CANDIDATES+=("/home/eh/projects/morgen-cli/.claude/worktrees/endpoint-discovery")
+MG_DEFAULT=""
+for c in "${MG_CANDIDATES[@]}"; do
+  if [ -f "$c/src/cdp-endpoint.ts" ]; then
+    MG_DEFAULT="$c"
+    break
+  fi
+done
+MG="${MORGEN_REPO:-$MG_DEFAULT}"
 fails=0
 note() { printf '  %-6s %s\n' "$1" "$2"; }
 
@@ -56,8 +82,12 @@ for pair in "MG:$MG" "SH:$SH"; do
     precheck_fail=1
     continue
   fi
-  if [ ! -r "$dir/src/cdp-endpoint.ts" ]; then
-    echo "FATAL: \$$label/src/cdp-endpoint.ts is missing or unreadable: $dir/src/cdp-endpoint.ts" >&2
+  if [ ! -f "$dir/src/cdp-endpoint.ts" ] || [ ! -r "$dir/src/cdp-endpoint.ts" ]; then
+    echo "FATAL: \$$label/src/cdp-endpoint.ts is missing, not a regular file, or unreadable: $dir/src/cdp-endpoint.ts" >&2
+    precheck_fail=1
+  fi
+  if [ ! -x "$dir" ]; then
+    echo "FATAL: \$$label repo dir is not traversable (missing execute bit): $dir" >&2
     precheck_fail=1
   fi
 done
@@ -149,10 +179,30 @@ s=$(cd "$SH" && bun test 2>&1 | grep -oE '[0-9]+ fail' | head -1)
 [ "$s" = "0 fail" ] && note PASS "superhuman $s" || { note FAIL "superhuman $s (run: account auth — E2E needs fresh tokens)"; fails=$((fails+1)); }
 
 echo "── G4 tsc vs baseline (morgen 75, superhuman 0) ──"
-mt=$(cd "$MG" && bunx tsc --noEmit --pretty false 2>&1 | grep -c 'error TS')
-st=$(cd "$SH" && bunx tsc --noEmit --pretty false 2>&1 | grep -c 'error TS')
-[ "$mt" -le 75 ] && note PASS "morgen $mt" || { note FAIL "morgen $mt > 75"; fails=$((fails+1)); }
-[ "$st" -eq 0 ] && note PASS "superhuman $st" || { note FAIL "superhuman $st > 0"; fails=$((fails+1)); }
+# `grep -c 'error TS'` alone is vacuous: a missing/broken bunx or tsc install
+# produces no matching lines, and 0 -le 75 / 0 -eq 0 both pass without tsc
+# ever having run. Require a POSITIVE signal first — `tsc --version` prints
+# a recognizable "Version X.Y.Z" line iff tsc actually executed — before
+# trusting the error count from the real run.
+tsc_ran() {
+  local repo="$1" ver
+  ver=$(cd "$repo" && bunx tsc --version 2>&1)
+  [[ "$ver" =~ Version[[:space:]][0-9]+\.[0-9]+\.[0-9]+ ]]
+}
+if tsc_ran "$MG"; then
+  mt=$(cd "$MG" && bunx tsc --noEmit --pretty false 2>&1 | grep -c 'error TS')
+  [ "$mt" -le 75 ] && note PASS "morgen $mt" || { note FAIL "morgen $mt > 75"; fails=$((fails+1)); }
+else
+  note FAIL "morgen tsc did not run (bunx/tsc unavailable — 'tsc --version' produced no recognizable output)"
+  fails=$((fails+1))
+fi
+if tsc_ran "$SH"; then
+  st=$(cd "$SH" && bunx tsc --noEmit --pretty false 2>&1 | grep -c 'error TS')
+  [ "$st" -eq 0 ] && note PASS "superhuman $st" || { note FAIL "superhuman $st > 0"; fails=$((fails+1)); }
+else
+  note FAIL "superhuman tsc did not run (bunx/tsc unavailable — 'tsc --version' produced no recognizable output)"
+  fails=$((fails+1))
+fi
 
 echo ""
 echo "SUBSTRATE: $([ $fails -eq 0 ] && echo CLEAN || echo "DIRTY ($fails gate(s) failing)")"

--- a/scripts/cdp-substrate-gate.sh
+++ b/scripts/cdp-substrate-gate.sh
@@ -9,39 +9,98 @@
 #              across both repos. Six drift incidents, every one from editing one
 #              file and asserting identity without running diff.
 #
-#   G2 ROLE    no target that MAIN's selectors accept may be rejected by the
-#              branch's, and no target main REJECTS may be accepted. Catches both
-#              "I broke Mac auth" (false negative) and "I widened role so account
-#              auth picks the login page" (false positive) — the two HIGHs I
-#              introduced while hardening.
+#   G2 ROLE    a hand-written regression-case table of real + impostor targets,
+#              checked against EACH branch's OWN classifier. This is NOT a diff
+#              against main's classifier — `src/cdp-endpoint.ts` has never
+#              existed on main (`git show main:src/cdp-endpoint.ts` fails with
+#              "exists on disk, but not in 'main'"); the file is new on this
+#              branch, so there is no main baseline to differential against.
+#              The case table is my own judgment call, written to catch the two
+#              HIGHs I introduced while hardening ("I broke Mac auth" / false
+#              negative, and "I widened role so account auth picks the login
+#              page" / false positive) — treat it as a regression list, not a
+#              mechanical proof of correctness against main.
 #
 #   G3 TESTS   both suites at baseline.
 #   G4 TSC     no new type errors.
 #
 # Exit 0 = substrate clean.
+#
+# G1's and G2's inputs are two sibling repos. Resolve them robustly instead of
+# hardcoding worktree paths that vanish once a branch merges or a worktree is
+# removed: SH defaults to this script's own repo (git rev-parse), MG must be
+# supplied via env or falls back to a documented default that is verified to
+# exist below — if either resolved path, or either cdp-endpoint.ts inside it,
+# is missing/unreadable, the whole run aborts loudly instead of silently
+# comparing empty files.
 set -uo pipefail
 
-MG=/home/eh/projects/morgen-cli/.claude/worktrees/endpoint-discovery
-SH=/home/eh/projects/superhuman-cli/.claude/worktrees/endpoint-discovery
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SH="${SUPERHUMAN_REPO:-$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null)}"
+MG="${MORGEN_REPO:-/home/eh/projects/morgen-cli/.claude/worktrees/endpoint-discovery}"
 fails=0
 note() { printf '  %-6s %s\n' "$1" "$2"; }
 
-echo "── G1 drift: shared section byte-identical ──"
-sed -n '/END PRODUCT BLOCK/,$p' "$MG/src/cdp-endpoint.ts" > /tmp/g1a.ts
-sed -n '/END PRODUCT BLOCK/,$p' "$SH/src/cdp-endpoint.ts" > /tmp/g1b.ts
-if diff -q /tmp/g1a.ts /tmp/g1b.ts >/dev/null 2>&1; then
-  note PASS "identical ($(wc -l < /tmp/g1a.ts) lines)"
-else
-  note FAIL "DRIFTED — $(diff /tmp/g1a.ts /tmp/g1b.ts | grep -c '^[<>]') differing lines"
-  fails=$((fails+1))
+# ── Precheck: both repos and both source files must exist and be readable. ──
+# G1-G4 are meaningless (or, worse, vacuously green) if any of these are absent.
+precheck_fail=0
+for pair in "MG:$MG" "SH:$SH"; do
+  label="${pair%%:*}"; dir="${pair#*:}"
+  if [ -z "$dir" ]; then
+    echo "FATAL: \$$label did not resolve to a path (set ${label}_REPO / SUPERHUMAN_REPO / MORGEN_REPO)" >&2
+    precheck_fail=1
+    continue
+  fi
+  if [ ! -d "$dir" ]; then
+    echo "FATAL: \$$label repo dir does not exist: $dir" >&2
+    precheck_fail=1
+    continue
+  fi
+  if [ ! -r "$dir/src/cdp-endpoint.ts" ]; then
+    echo "FATAL: \$$label/src/cdp-endpoint.ts is missing or unreadable: $dir/src/cdp-endpoint.ts" >&2
+    precheck_fail=1
+  fi
+done
+if [ "$precheck_fail" -ne 0 ]; then
+  echo "" >&2
+  echo "SUBSTRATE: ABORTED — cannot evaluate gates without both real repos present." >&2
+  exit 1
 fi
 
-echo "── G2 role: branch selectors vs main's, on real + impostor targets ──"
+echo "── G1 drift: shared section byte-identical ──"
+MARKER='END PRODUCT BLOCK'
+marker_fail=0
+if ! grep -q "$MARKER" "$MG/src/cdp-endpoint.ts"; then
+  note FAIL "marker '$MARKER' not found in $MG/src/cdp-endpoint.ts"
+  marker_fail=1
+fi
+if ! grep -q "$MARKER" "$SH/src/cdp-endpoint.ts"; then
+  note FAIL "marker '$MARKER' not found in $SH/src/cdp-endpoint.ts"
+  marker_fail=1
+fi
+if [ "$marker_fail" -ne 0 ]; then
+  fails=$((fails+1))
+else
+  sed -n "/${MARKER}/,\$p" "$MG/src/cdp-endpoint.ts" > /tmp/g1a.ts
+  sed -n "/${MARKER}/,\$p" "$SH/src/cdp-endpoint.ts" > /tmp/g1b.ts
+  if [ ! -s /tmp/g1a.ts ] || [ ! -s /tmp/g1b.ts ]; then
+    note FAIL "extracted block is empty despite marker being present — refusing to diff empty files"
+    fails=$((fails+1))
+  elif diff -q /tmp/g1a.ts /tmp/g1b.ts >/dev/null 2>&1; then
+    note PASS "identical ($(wc -l < /tmp/g1a.ts) lines)"
+  else
+    note FAIL "DRIFTED — $(diff /tmp/g1a.ts /tmp/g1b.ts | grep -c '^[<>]') differing lines"
+    fails=$((fails+1))
+  fi
+fi
+
+echo "── G2 regression cases: each branch's own classifier vs a hand-written table (NOT a diff against main — see header) ──"
 run_g2() {
   local repo="$1" name="$2"
   ( cd "$repo" && timeout 60 bun -e '
     import { classifyTarget } from "./src/cdp-endpoint";
-    // [url, mustBe] — derived from what MAIN accepted, plus impostors main also rejected.
+    // [url, mustBe] — hand-written expected-classification table (NOT a diff against
+    // main; main has never had this file — see the G2 header comment above).
     const cases: [string, string|null][] = JSON.parse(process.env.G2_CASES!);
     let bad = 0;
     for (const [url, want] of cases) {
@@ -52,7 +111,8 @@ run_g2() {
   ' ) 2>&1
 }
 
-# morgen: main accepted morgen:// and *morgen.so*; impostors main also rejected.
+# morgen: expected-good hosts/schemes plus impostor hosts that must be rejected.
+# (hand-written regression table, not a diff against main — see G2 header comment.)
 export G2_CASES='[
   ["morgen://./app.html","electron"],
   ["file:///opt/Morgen/resources/app.html","electron"],

--- a/scripts/cdp-substrate-gate.test.sh
+++ b/scripts/cdp-substrate-gate.test.sh
@@ -52,13 +52,64 @@ else
 fi
 
 # --- Test 3: gate must PASS on the real, current, correct repos ---
-out3=$(bash "$GATE" 2>&1)
+# Hermetic: pass MORGEN_REPO/SUPERHUMAN_REPO explicitly so this does not
+# depend on the hardcoded worktree default (which vanishes once the branch
+# merges and the worktree is removed).
+: "${MORGEN_REPO:=/home/eh/projects/morgen-cli/.claude/worktrees/endpoint-discovery}"
+: "${SUPERHUMAN_REPO:=$HERE/..}"
+SUPERHUMAN_REPO="$(cd "$SUPERHUMAN_REPO" && pwd)"
+out3=$(MORGEN_REPO="$MORGEN_REPO" SUPERHUMAN_REPO="$SUPERHUMAN_REPO" bash "$GATE" 2>&1)
 rc3=$?
 if [ "$rc3" -eq 0 ]; then
-  pass "test3: gate exits 0 on real repos"
+  pass "test3: gate exits 0 on real repos with explicit MORGEN_REPO/SUPERHUMAN_REPO"
 else
   fail "test3: expected exit 0 on real repos, got rc=$rc3"
   echo "$out3"
+fi
+
+# --- Test 4: gate must FAIL (not vacuously PASS) when tsc cannot run (G4) ---
+stubdir=$(mktemp -d)
+cat > "$stubdir/bunx" <<'STUB'
+#!/usr/bin/env bash
+# Simulate a broken/missing tsc install: bunx itself fails, no tsc output at all.
+echo "bunx: command not found (stub)" >&2
+exit 127
+STUB
+chmod +x "$stubdir/bunx"
+out4=$(PATH="$stubdir:$PATH" MORGEN_REPO="$MORGEN_REPO" SUPERHUMAN_REPO="$SUPERHUMAN_REPO" bash "$GATE" 2>&1)
+rc4=$?
+rm -rf "$stubdir"
+if [ "$rc4" -ne 0 ]; then
+  pass "test4: nonzero exit when bunx/tsc cannot run (rc=$rc4)"
+else
+  fail "test4: expected nonzero exit when bunx/tsc cannot run, got rc=0"
+fi
+if echo "$out4" | grep -qE 'PASS[[:space:]]+(morgen|superhuman) 0$'; then
+  fail "test4: vacuous 'PASS ... 0' still present when tsc never ran"
+else
+  pass "test4: no vacuous tsc-never-ran PASS output"
+fi
+
+# --- Test 5: gate must FAIL (not vacuously PASS) when the test runner cannot run (G3) ---
+stubdir=$(mktemp -d)
+cat > "$stubdir/bun" <<'STUB'
+#!/usr/bin/env bash
+echo "bun: command not found (stub)" >&2
+exit 127
+STUB
+chmod +x "$stubdir/bun"
+out5=$(PATH="$stubdir:$PATH" MORGEN_REPO="$MORGEN_REPO" SUPERHUMAN_REPO="$SUPERHUMAN_REPO" bash "$GATE" 2>&1)
+rc5=$?
+rm -rf "$stubdir"
+if [ "$rc5" -ne 0 ]; then
+  pass "test5: nonzero exit when bun/test runner cannot run (rc=$rc5)"
+else
+  fail "test5: expected nonzero exit when bun cannot run, got rc=0"
+fi
+if echo "$out5" | grep -qE 'PASS[[:space:]]+(morgen|superhuman) 0 fail$'; then
+  fail "test5: vacuous 'PASS ... 0 fail' still present when bun never ran"
+else
+  pass "test5: no vacuous test-never-ran PASS output"
 fi
 
 echo ""

--- a/scripts/cdp-substrate-gate.test.sh
+++ b/scripts/cdp-substrate-gate.test.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Regression tests for scripts/cdp-substrate-gate.sh.
+#
+# These exist because the gate previously reported PASS on G1 (drift) when its
+# input files were missing/unreadable: `sed` on an unreadable file silently
+# writes an empty output file, and `diff -q` on two empty files succeeds.
+#
+# Run: bash scripts/cdp-substrate-gate.test.sh
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GATE="$HERE/cdp-substrate-gate.sh"
+fails=0
+pass() { printf 'PASS  %s\n' "$1"; }
+fail() { printf 'FAIL  %s\n' "$1"; fails=$((fails+1)); }
+
+# --- Test 1: gate must FAIL (nonzero exit) when a repo path is missing/unreadable ---
+out1=$(MORGEN_REPO=/tmp/cdp-gate-test-does-not-exist \
+       SUPERHUMAN_REPO=/tmp/cdp-gate-test-does-not-exist \
+       bash "$GATE" 2>&1)
+rc1=$?
+if [ "$rc1" -ne 0 ]; then
+  pass "test1: nonzero exit when repo paths missing (rc=$rc1)"
+else
+  fail "test1: expected nonzero exit when repo paths missing, got rc=0"
+fi
+if echo "$out1" | grep -qi 'PASS identical (0 lines)'; then
+  fail "test1: vacuous 'PASS identical (0 lines)' still present with missing repos"
+else
+  pass "test1: no vacuous 'PASS identical (0 lines)' output"
+fi
+
+# --- Test 2: gate must FAIL when the END PRODUCT BLOCK marker is absent ---
+tmpA=$(mktemp -d)
+tmpB=$(mktemp -d)
+mkdir -p "$tmpA/src" "$tmpB/src"
+# Real content, but with the marker comment stripped from one side.
+printf 'export const x = 1;\n// no marker here\nexport const y = 2;\n' > "$tmpA/src/cdp-endpoint.ts"
+printf 'export const x = 1;\n// no marker here\nexport const y = 2;\n' > "$tmpB/src/cdp-endpoint.ts"
+out2=$(MORGEN_REPO="$tmpA" SUPERHUMAN_REPO="$tmpB" bash "$GATE" 2>&1)
+rc2=$?
+rm -rf "$tmpA" "$tmpB"
+if [ "$rc2" -ne 0 ]; then
+  pass "test2: nonzero exit when END PRODUCT BLOCK marker is absent (rc=$rc2)"
+else
+  fail "test2: expected nonzero exit when marker absent, got rc=0"
+fi
+if echo "$out2" | grep -qi 'PASS identical (0 lines)'; then
+  fail "test2: vacuous 'PASS identical (0 lines)' still present with no marker"
+else
+  pass "test2: no vacuous 'PASS identical (0 lines)' output"
+fi
+
+# --- Test 3: gate must PASS on the real, current, correct repos ---
+out3=$(bash "$GATE" 2>&1)
+rc3=$?
+if [ "$rc3" -eq 0 ]; then
+  pass "test3: gate exits 0 on real repos"
+else
+  fail "test3: expected exit 0 on real repos, got rc=$rc3"
+  echo "$out3"
+fi
+
+echo ""
+if [ "$fails" -eq 0 ]; then
+  echo "ALL TESTS PASS"
+  exit 0
+else
+  echo "$fails TEST(S) FAILED"
+  exit 1
+fi

--- a/src/__tests__/cdp-endpoint-classify.test.ts
+++ b/src/__tests__/cdp-endpoint-classify.test.ts
@@ -1,0 +1,51 @@
+import { test, expect, describe } from "bun:test";
+import { classifyTarget, rankTargets } from "../cdp-endpoint";
+
+function page(url: string) {
+  return { type: "page", url };
+}
+
+describe("isElectronTarget apex-fallback regression", () => {
+  test("accounts.superhuman.com/background_page.html is NOT electron", () => {
+    expect(
+      classifyTarget(page("https://accounts.superhuman.com/background_page.html"))
+    ).not.toBe("electron");
+  });
+
+  test("accounts.superhuman.com/background_page.html classifies as null (not chrome either)", () => {
+    // It is not the web app's inbox host, so it must not win any role.
+    expect(
+      classifyTarget(page("https://accounts.superhuman.com/background_page.html"))
+    ).toBeNull();
+  });
+
+  test("an impostor background_page.html on a non-superhuman subdomain does not outrank the real mail tab in rankTargets", () => {
+    const targets = [
+      page("https://accounts.superhuman.com/background_page.html"),
+      page("https://mail.superhuman.com/e@x.com/inbox"),
+    ];
+    const ranked = rankTargets(targets);
+    // The real mail tab must be present and must not be beaten by the impostor
+    // classifying as "electron" (which ranks first).
+    expect(ranked.some((r) => r.source === "chrome" && r.target === targets[1])).toBe(true);
+    expect(ranked.some((r) => r.source === "electron" && r.target === targets[0])).toBe(false);
+  });
+});
+
+describe("real Electron/web shapes must keep classifying (false negative is worse)", () => {
+  test("superhuman-app://superhuman.com/background_page.html -> electron", () => {
+    expect(
+      classifyTarget(page("superhuman-app://superhuman.com/background_page.html"))
+    ).toBe("electron");
+  });
+
+  test("https://mail.superhuman.com/~backend/build/background_page.html -> electron", () => {
+    expect(
+      classifyTarget(page("https://mail.superhuman.com/~backend/build/background_page.html"))
+    ).toBe("electron");
+  });
+
+  test("https://mail.superhuman.com/e@x.com/inbox -> chrome", () => {
+    expect(classifyTarget(page("https://mail.superhuman.com/e@x.com/inbox"))).toBe("chrome");
+  });
+});

--- a/src/__tests__/cdp-env.test.ts
+++ b/src/__tests__/cdp-env.test.ts
@@ -51,10 +51,30 @@ describe("getCDPPort", () => {
 });
 
 describe("discoverSuperhumanPort", () => {
-  test("honors explicit CDP_PORT without probing", async () => {
+  test("explicit CDP_PORT is the only candidate probed", async () => {
+    // The previous version of this test asserted only the return value, which
+    // 9400 satisfies via the ERROR path too (probe fails -> catch ->
+    // getCDPPort() -> 9400). It could not tell "honored" from "discovery
+    // completely broken". Assert what is actually load-bearing: no OTHER port
+    // is touched.
     process.env.CDP_PORT = "9400";
-    // Explicit override must win and short-circuit any CDP probing.
-    expect(await discoverSuperhumanPort()).toBe(9400);
+    const CDP = (await import("chrome-remote-interface")).default as any;
+    const realList = CDP.List;
+    const listed: number[] = [];
+    CDP.List = async (opts: any) => {
+      listed.push(opts.port);
+      return [{ type: "page", url: "https://mail.superhuman.com/inbox" }];
+    };
+    try {
+      const { resetEndpointCache } = await import("../cdp-endpoint");
+      resetEndpointCache();
+      expect(await discoverSuperhumanPort()).toBe(9400);
+      expect(listed).toEqual([9400]); // never 9252, never 9222
+    } finally {
+      CDP.List = realList;
+      const { resetEndpointCache } = await import("../cdp-endpoint");
+      resetEndpointCache();
+    }
   });
 });
 

--- a/src/app-health.ts
+++ b/src/app-health.ts
@@ -19,6 +19,7 @@
  * investigation of recurring focus stealing.
  */
 import CDP from "chrome-remote-interface";
+import { classifyTarget } from "./cdp-endpoint";
 import { getCDPHost, getCDPPort } from "./superhuman-api";
 
 const APP_PATH = "/Applications/Superhuman.app";
@@ -37,12 +38,10 @@ export async function isBackgroundPageReachable(
 ): Promise<boolean> {
   try {
     const targets = await CDP.List({ host: getCDPHost(), port });
-    return targets.some(
-      (t: any) =>
-        t.type === "page" &&
-        t.url.includes("background_page.html") &&
-        t.url.includes("superhuman"),
-    );
+    // classifyTarget, not substrings. This module having its own matcher is how
+    // the classifier's superhuman-app:// blind spot stayed hidden: app-health
+    // kept reporting the desktop app healthy while discovery could not see it.
+    return targets.some((t: any) => classifyTarget(t) === "electron");
   } catch {
     return false;
   }

--- a/src/background-page-refresh.ts
+++ b/src/background-page-refresh.ts
@@ -17,6 +17,7 @@
  * Credential Refresh".
  */
 import CDP from "chrome-remote-interface";
+import { classifyTarget } from "./cdp-endpoint";
 import { getCDPHost, getCDPPort } from "./superhuman-api";
 import type { TokenInfo } from "./token-api";
 
@@ -46,12 +47,11 @@ export async function connectToBackgroundPage(
     return null;
   }
 
-  const bgPage = targets.find(
-    (t: any) =>
-      t.type === "page" &&
-      t.url.includes("background_page.html") &&
-      t.url.includes("superhuman"),
-  );
+  // classifyTarget, not substrings: this function ATTACHES to the target and
+  // runs credential-refresh JavaScript in its contexts, so
+  // https://evil.example/superhuman/background_page.html satisfying the old
+  // check was the forged-target class the classifier exists to prevent.
+  const bgPage = targets.find((t: any) => classifyTarget(t) === "electron");
   if (!bgPage) return null;
 
   let client: CDP.Client;

--- a/src/cdp-endpoint.ts
+++ b/src/cdp-endpoint.ts
@@ -22,7 +22,7 @@
  * ECONNREFUSED unless the user knew to set CDP_PORT by hand.
  *
  * Ports (all overridable, see cdpPortCandidates):
- *   CDP_PORT           explicit single port; wins outright, skips probing
+ *   CDP_PORT           pin to one port (still listed; no other candidate tried)
  *   ELECTRON_CDP_PORT  the desktop app's port      (default below)
  *   CHROME_CDP_PORT    Chrome/Chromium's port      (default below)
  */
@@ -168,8 +168,11 @@ function envPort(name: string): number | undefined {
 /**
  * CDP endpoints to probe, in preference order: the desktop app, then the browser.
  *
- * An explicit CDP_PORT wins outright — if the user names a port, probing past it
- * would be second-guessing them.
+ * An explicit CDP_PORT pins the list to that one port: if the user names a port,
+ * probing past it would be second-guessing them. It does NOT skip discovery —
+ * that port is still listed to find targets on it, so a firewalled host costs
+ * one cdpTimeoutMs before failing. Naming a port is not the same as promising
+ * something is there.
  */
 export function cdpPortCandidates(): number[] {
   const explicit = envPort("CDP_PORT");

--- a/src/cdp-endpoint.ts
+++ b/src/cdp-endpoint.ts
@@ -274,11 +274,15 @@ export async function discoverEndpoint(): Promise<Endpoint> {
         `listing targets on port ${port}`
       );
       if (rankTargets(targets).length > 0) return { port, targets };
+      // Listed fine, but nothing of ours is there any more — re-listing it
+      // below would just repeat that answer, so skip it.
+      skip = port;
     } catch {
-      // fall through to rediscovery
+      // A transient error (EPIPE, a blip) is NOT evidence the port is wrong, so
+      // it stays a candidate: skipping it here failed the whole call while the
+      // port was healthy a moment later.
     }
     discoveredPort = null;
-    skip = port; // already tried; do not probe it twice
   }
 
   const candidates = cdpPortCandidates();

--- a/src/cdp-endpoint.ts
+++ b/src/cdp-endpoint.ts
@@ -1,0 +1,254 @@
+/**
+ * CDP Endpoint Discovery
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * DELIBERATELY NEAR-IDENTICAL to src/cdp-endpoint.ts in morgen-cli.
+ * Only the PRODUCT BLOCK below differs. Keep it that way: both CLIs face the
+ * same problem, and one flow you can learn once is worth more than two clever
+ * ones. If you fix a bug here, fix it there.
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * Both products ship two deployments, and they are DIFFERENT CDP ENDPOINTS —
+ * not different tabs on one endpoint:
+ *
+ *   1. the Electron desktop app  — macOS; listens on its own debug port
+ *   2. Chrome/Chromium           — the web app; listens on the browser's port
+ *
+ * So: look for the Electron app first, then fall back to Chrome/Chromium.
+ *
+ * Getting this wrong is not theoretical. The sibling CLI hardcoded a single port
+ * and never probed, so on Linux — where the desktop app does not exist and the
+ * web app runs in Chromium on 9222 — every command failed with a bare
+ * ECONNREFUSED unless the user knew to set CDP_PORT by hand.
+ *
+ * Ports (all overridable, see cdpPortCandidates):
+ *   CDP_PORT           explicit single port; wins outright, skips probing
+ *   ELECTRON_CDP_PORT  the desktop app's port      (default below)
+ *   CHROME_CDP_PORT    Chrome/Chromium's port      (default below)
+ */
+
+import CDP from "chrome-remote-interface";
+
+// ─── PRODUCT BLOCK — the only part that differs from the sibling CLI ─────────
+
+/** Human name, for error text. */
+const PRODUCT = "Superhuman";
+
+/**
+ * The desktop app's debug port.
+ *
+ * What the `com.user.superhuman-cdp` LaunchAgent passes via
+ * `--remote-debugging-port=9252`, and the only target exposing
+ * `background_page.html` for the Electron refresh path.
+ */
+const DEFAULT_ELECTRON_PORT = 9252;
+
+/** Chrome/Chromium's debug port, where the extension runs. */
+const DEFAULT_CHROME_PORT = 9222;
+
+/**
+ * Is this target the product's Electron desktop app?
+ *
+ * The desktop app is the one exposing background_page.html; the Chrome
+ * extension has no background_page at all. Matching on that rather than a URL
+ * scheme is what distinguishes the two deployments here.
+ */
+function isElectronTarget(url: string): boolean {
+  return url.includes("background_page.html") && /superhuman/i.test(url);
+}
+
+/** Is this target the product's web app in a browser? */
+function isWebTarget(url: string): boolean {
+  return url.includes("superhuman.com");
+}
+
+/** Command that starts the desktop app with CDP, per platform. */
+function electronLaunchHint(port: number, platform: string = process.platform): string {
+  const bin =
+    platform === "darwin"
+      ? "/Applications/Superhuman.app/Contents/MacOS/Superhuman"
+      : platform === "win32"
+        ? "%LOCALAPPDATA%\\Programs\\Superhuman\\Superhuman.exe"
+        : "superhuman"; // Linux: no desktop app ships today; the extension is the route
+  return `${bin} --remote-debugging-port=${port}`;
+}
+
+/** Where the web app lives, for error text. */
+const WEB_APP_URL = "https://mail.superhuman.com";
+
+// ─── END PRODUCT BLOCK — everything below is identical across both CLIs ──────
+
+export type ConnectionSource = "electron" | "chrome";
+
+const DEFAULT_CDP_TIMEOUT_MS = 10_000;
+/** setTimeout's 32-bit ceiling; beyond this it silently clamps to 1ms. */
+const MAX_CDP_TIMEOUT_MS = 2_147_483_647;
+
+/**
+ * Upper bound on a single CDP round-trip.
+ *
+ * Resolved at call time, not import time: a module-level const captures the env
+ * before a test (or a caller) can set it.
+ *
+ * Validated rather than trusted. parseInt("garbage") is NaN and
+ * setTimeout(fn, NaN) fires immediately; anything past the 32-bit ceiling is
+ * clamped to 1ms. Either would make every call "time out" instantly with a
+ * misleading message — the exact failure this guard exists to prevent.
+ */
+export function cdpTimeoutMs(): number {
+  const raw = process.env.CDP_TIMEOUT_MS;
+  if (!raw) return DEFAULT_CDP_TIMEOUT_MS;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 1 || n > MAX_CDP_TIMEOUT_MS) return DEFAULT_CDP_TIMEOUT_MS;
+  return n;
+}
+
+/** Reject rather than wait forever — an unbounded CDP wait hangs the CLI silently. */
+export function withTimeout<T>(p: Promise<T>, what: string, ms = cdpTimeoutMs()): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`${what} timed out after ${ms}ms — is the ${PRODUCT} tab responsive?`)),
+      ms
+    );
+    p.then(
+      (v) => {
+        clearTimeout(timer);
+        resolve(v);
+      },
+      (e) => {
+        clearTimeout(timer);
+        reject(e);
+      }
+    );
+  });
+}
+
+/** Read a positive integer port from the environment, or undefined. */
+function envPort(name: string): number | undefined {
+  const raw = process.env[name];
+  if (!raw) return undefined;
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 1 || n > 65535) return undefined;
+  return n;
+}
+
+/**
+ * CDP endpoints to probe, in preference order: the desktop app, then the browser.
+ *
+ * An explicit CDP_PORT wins outright — if the user names a port, probing past it
+ * would be second-guessing them.
+ */
+export function cdpPortCandidates(): number[] {
+  const explicit = envPort("CDP_PORT");
+  if (explicit) return [explicit];
+  return [
+    envPort("ELECTRON_CDP_PORT") ?? DEFAULT_ELECTRON_PORT,
+    envPort("CHROME_CDP_PORT") ?? DEFAULT_CHROME_PORT,
+  ];
+}
+
+export function getCDPHost(): string {
+  return process.env.CDP_HOST || process.env.HOST_IP || "localhost";
+}
+
+/** Classify a CDP target as the desktop app, the web app, or neither. */
+export function classifyTarget(t: any): ConnectionSource | null {
+  if (t?.type !== "page") return null;
+  const url: string | undefined = t.url;
+  if (!url) return null;
+  if (isElectronTarget(url)) return "electron";
+  if (isWebTarget(url)) return "chrome";
+  return null;
+}
+
+/**
+ * Rank every viable target, best first: the desktop app before the web app.
+ *
+ * Every one, not just the best. A CDP command routed through a page goes through
+ * its renderer, and a busy renderer never answers — measured, 4 of 8 live page
+ * targets were wedged at one point, and which ones drift over time. Committing
+ * to a single target lets one wedged tab fail a refresh another target could
+ * have served.
+ */
+export function rankTargets<T>(targets: T[]): Array<{ source: ConnectionSource; target: T }> {
+  const ranked: Array<{ source: ConnectionSource; target: T }> = [];
+  for (const source of ["electron", "chrome"] as const) {
+    for (const target of targets) {
+      if (classifyTarget(target) === source) ranked.push({ source, target });
+    }
+  }
+  return ranked;
+}
+
+/** Error text naming both routes — either satisfies the CLI, and only one exists per platform. */
+export function noTargetHint(ports: number[], platform: string = process.platform): string {
+  return (
+    `No ${PRODUCT} target found (probed port${ports.length > 1 ? "s" : ""} ${ports.join(", ")}).\n` +
+    "Start either route (quit the app first if already open, so the debug port takes effect):\n" +
+    `  Desktop app: ${electronLaunchHint(envPort("ELECTRON_CDP_PORT") ?? DEFAULT_ELECTRON_PORT, platform)}\n` +
+    `  Web app:     open ${WEB_APP_URL} in a browser started with --remote-debugging-port=${
+      envPort("CHROME_CDP_PORT") ?? DEFAULT_CHROME_PORT
+    }`
+  );
+}
+
+/** A discovered endpoint: the port, and the targets it is serving. */
+export interface Endpoint {
+  port: number;
+  targets: any[];
+}
+
+/**
+ * The PORT is cached for the process lifetime; the targets never are.
+ *
+ * Probing costs a round-trip per candidate, and the port will not move under a
+ * running CLI. Targets will: tabs open and close constantly, so a cached target
+ * list is stale the moment it is taken.
+ */
+let discoveredPort: number | null = null;
+
+/** Reset the discovery cache. Tests only. */
+export function resetEndpointCache(): void {
+  discoveredPort = null;
+}
+
+/**
+ * Find the CDP endpoint serving the product: the desktop app first, then the browser.
+ *
+ * Returns the first candidate port that has any viable target. A port that is
+ * listening but serving something else (a headless Chrome for another tool, say)
+ * is skipped rather than accepted — reachable is not the same as ours.
+ *
+ * Targets are always listed fresh, even on the cached-port path.
+ */
+export async function discoverEndpoint(): Promise<Endpoint> {
+  const host = getCDPHost();
+
+  if (discoveredPort !== null) {
+    const port = discoveredPort;
+    const targets = await withTimeout(
+      CDP.List({ host, port }) as Promise<any[]>,
+      `listing targets on port ${port}`
+    );
+    return { port, targets };
+  }
+
+  const candidates = cdpPortCandidates();
+  for (const port of candidates) {
+    let targets: any[];
+    try {
+      targets = await withTimeout(
+        CDP.List({ host, port }) as Promise<any[]>,
+        `listing targets on port ${port}`
+      );
+    } catch {
+      continue; // not listening, or not answering — try the next candidate
+    }
+    if (rankTargets(targets).length > 0) {
+      discoveredPort = port;
+      return { port, targets };
+    }
+  }
+
+  throw new Error(noTargetHint(candidates));
+}

--- a/src/cdp-endpoint.ts
+++ b/src/cdp-endpoint.ts
@@ -50,11 +50,23 @@ const DEFAULT_CHROME_PORT = 9222;
  * Is this target the product's Electron desktop app?
  *
  * The desktop app is the one exposing background_page.html; the Chrome
- * extension has no background_page at all. Matching on that rather than a URL
- * scheme is what distinguishes the two deployments here.
+ * extension has no background_page at all. That, not a URL scheme, is what
+ * distinguishes the deployments here.
+ *
+ * The host must still be ours. Electron ranks FIRST, so a false positive does
+ * not merely add noise — it beats the genuine tab and gets credential-reading
+ * code pointed at the impostor. A bare substring test accepted
+ * https://evil.example/superhuman/background_page.html; the sibling CLI had the
+ * same hole with /morgen/i and it ranked an attacker page ahead of the real one.
+ *
+ * file:// is allowed because a packaged app can serve background_page.html from
+ * its install dir; forging that needs local filesystem access, by which point
+ * the credential store is already readable.
  */
 function isElectronTarget(url: string): boolean {
-  return url.includes("background_page.html") && /superhuman/i.test(url);
+  if (!url.includes("background_page.html")) return false;
+  if (url.startsWith("file://")) return /superhuman/i.test(url);
+  return hostMatches(url, "superhuman.com");
 }
 
 /** Is this target the product's web app in a browser? */

--- a/src/cdp-endpoint.ts
+++ b/src/cdp-endpoint.ts
@@ -88,9 +88,12 @@ function isElectronTarget(url: string): boolean {
   // local filesystem access, by which point the credential store is readable.
   if (u.protocol === "file:") return /superhuman/i.test(url);
 
-  // Otherwise the host must genuinely be ours. Electron ranks FIRST, so an
-  // impostor here beats the real tab and gets the credential read pointed at it.
-  return hostMatches(url, "superhuman.com");
+  // Otherwise the host must genuinely be the web app's, not merely the apex
+  // domain: hostMatches(url, "superhuman.com") also accepted
+  // accounts.superhuman.com/background_page.html. Electron ranks FIRST, so an
+  // impostor here beats the real mail tab and gets the credential read
+  // pointed at it — the same app-vs-domain distinction isWebTarget makes.
+  return hostMatches(url, "mail.superhuman.com");
 }
 
 /**

--- a/src/cdp-endpoint.ts
+++ b/src/cdp-endpoint.ts
@@ -93,9 +93,19 @@ function isElectronTarget(url: string): boolean {
   return hostMatches(url, "superhuman.com");
 }
 
-/** Is this target the product's web app in a browser? */
+/**
+ * Is this target the product's web app in a browser?
+ *
+ * The APP, not the domain. hostMatches("superhuman.com") is the right IDENTITY
+ * check and the wrong ROLE check: it also accepts accounts.superhuman.com/login
+ * and superhuman.com/blog. The code this replaced required mail.superhuman.com,
+ * so widening it regressed the auth path — connectToSuperhumanChrome picks the
+ * FIRST match, and the sign-in flow is exactly what leaves accounts.* open;
+ * connectToSuperhuman sorts by URL length, and a marketing slug outruns an inbox.
+ * Both then attach and run app-globals code in a page that has none.
+ */
 function isWebTarget(url: string): boolean {
-  return hostMatches(url, "superhuman.com");
+  return hostMatches(url, "mail.superhuman.com");
 }
 
 /** Command that starts the desktop app with CDP, per platform. */
@@ -178,8 +188,21 @@ export function hostMatches(url: string, domain: string): boolean {
     return false;
   }
   if (u.protocol !== "https:" && u.protocol !== "http:") return false;
-  const h = u.hostname.toLowerCase();
-  const d = domain.toLowerCase();
+
+  // Canonicalize before comparing. A fully qualified name carries a root dot —
+  // "web.morgen.so." is the SAME DNS name as "web.morgen.so", and the WHATWG
+  // parser preserves it. Rejecting it would exclude a genuine logged-in tab and
+  // report "no target": a false negative here breaks auth outright, which is
+  // worse than the substring hole this function replaced.
+  const canon = (h: string) => h.toLowerCase().replace(/\.$/, "");
+  const h = canon(u.hostname);
+  const d = canon(domain);
+
+  // An empty host, or a leading empty label (".morgen.so"), is not a real name.
+  if (!h || !d || h.startsWith(".")) return false;
+
+  // Note: userinfo cannot fool this — new URL("https://morgen.so@evil.example/")
+  // has hostname "evil.example", and a port lives outside hostname.
   return h === d || h.endsWith(`.${d}`);
 }
 
@@ -284,8 +307,14 @@ export function resetEndpointCache(): void {
  *
  * Targets are always listed fresh, even on the cached-port path.
  */
-export async function discoverEndpoint(): Promise<Endpoint> {
+export async function discoverEndpoint(remaining?: () => number): Promise<Endpoint> {
   const host = getCDPHost();
+  // Every List is bounded by the SMALLER of one round-trip and whatever the
+  // caller has left. Without the caller's budget, discovery hands each probe a
+  // fresh full timeout and can outlast the very deadline the caller started
+  // before calling us — leaving zero time to attach to the target it just found.
+  const budget = () =>
+    remaining ? Math.min(remaining(), cdpTimeoutMs()) : cdpTimeoutMs();
 
   // A cached port is a hint, not a verdict. The app can move between
   // deployments inside one process — quit Electron on its port, open the web
@@ -298,7 +327,8 @@ export async function discoverEndpoint(): Promise<Endpoint> {
     try {
       const targets = await withTimeout(
         CDP.List({ host, port }) as Promise<any[]>,
-        `listing targets on port ${port}`
+        `listing targets on port ${port}`,
+        budget()
       );
       if (rankTargets(targets).length > 0) return { port, targets };
       // Listed fine, but nothing of ours is there any more — re-listing it
@@ -315,11 +345,13 @@ export async function discoverEndpoint(): Promise<Endpoint> {
   const candidates = cdpPortCandidates();
   for (const port of candidates) {
     if (port === skip) continue;
+    if (remaining && remaining() <= 0) break;
     let targets: any[];
     try {
       targets = await withTimeout(
         CDP.List({ host, port }) as Promise<any[]>,
-        `listing targets on port ${port}`
+        `listing targets on port ${port}`,
+        budget()
       );
     } catch {
       continue; // not listening, or not answering — try the next candidate

--- a/src/cdp-endpoint.ts
+++ b/src/cdp-endpoint.ts
@@ -59,7 +59,7 @@ function isElectronTarget(url: string): boolean {
 
 /** Is this target the product's web app in a browser? */
 function isWebTarget(url: string): boolean {
-  return url.includes("superhuman.com");
+  return hostMatches(url, "superhuman.com");
 }
 
 /** Command that starts the desktop app with CDP, per platform. */
@@ -82,7 +82,7 @@ export type ConnectionSource = "electron" | "chrome";
 
 const DEFAULT_CDP_TIMEOUT_MS = 10_000;
 /** setTimeout's 32-bit ceiling; beyond this it silently clamps to 1ms. */
-const MAX_CDP_TIMEOUT_MS = 2_147_483_647;
+export const MAX_CDP_TIMEOUT_MS = 2_147_483_647;
 
 /**
  * Upper bound on a single CDP round-trip.
@@ -121,6 +121,27 @@ export function withTimeout<T>(p: Promise<T>, what: string, ms = cdpTimeoutMs())
       }
     );
   });
+}
+
+/**
+ * Does `url`'s HOSTNAME equal `domain`, or is it a subdomain of it?
+ *
+ * Never a substring test. `includes("morgen.so")` also matches
+ * https://morgen.so.evil.example/ and https://evil.example/?next=morgen.so — and
+ * discovery hands the winning target to code that runs credential-reading
+ * JavaScript in it, so a forged identity is not cosmetic.
+ */
+export function hostMatches(url: string, domain: string): boolean {
+  let u: URL;
+  try {
+    u = new URL(url);
+  } catch {
+    return false;
+  }
+  if (u.protocol !== "https:" && u.protocol !== "http:") return false;
+  const h = u.hostname.toLowerCase();
+  const d = domain.toLowerCase();
+  return h === d || h.endsWith(`.${d}`);
 }
 
 /** Read a positive integer port from the environment, or undefined. */
@@ -224,17 +245,30 @@ export function resetEndpointCache(): void {
 export async function discoverEndpoint(): Promise<Endpoint> {
   const host = getCDPHost();
 
+  // A cached port is a hint, not a verdict. The app can move between
+  // deployments inside one process — quit Electron on its port, open the web
+  // app in Chrome — and a long-lived caller (the MCP server) would otherwise
+  // fail forever against a port that is now dead, or worse, one some other
+  // service has since bound.
+  let skip: number | null = null;
   if (discoveredPort !== null) {
     const port = discoveredPort;
-    const targets = await withTimeout(
-      CDP.List({ host, port }) as Promise<any[]>,
-      `listing targets on port ${port}`
-    );
-    return { port, targets };
+    try {
+      const targets = await withTimeout(
+        CDP.List({ host, port }) as Promise<any[]>,
+        `listing targets on port ${port}`
+      );
+      if (rankTargets(targets).length > 0) return { port, targets };
+    } catch {
+      // fall through to rediscovery
+    }
+    discoveredPort = null;
+    skip = port; // already tried; do not probe it twice
   }
 
   const candidates = cdpPortCandidates();
   for (const port of candidates) {
+    if (port === skip) continue;
     let targets: any[];
     try {
       targets = await withTimeout(

--- a/src/cdp-endpoint.ts
+++ b/src/cdp-endpoint.ts
@@ -65,7 +65,31 @@ const DEFAULT_CHROME_PORT = 9222;
  */
 function isElectronTarget(url: string): boolean {
   if (!url.includes("background_page.html")) return false;
-  if (url.startsWith("file://")) return /superhuman/i.test(url);
+
+  // The desktop app serves its background page over its OWN scheme:
+  //   superhuman-app://superhuman.com/background_page.html
+  // Requiring http(s) rejected it outright — discovery skipped a healthy
+  // Electron endpoint and desktop token refresh broke. Nothing but the app can
+  // register this scheme, so an exact host+path check is the identity.
+  let u: URL | null = null;
+  try {
+    u = new URL(url);
+  } catch {
+    return false;
+  }
+  if (u.protocol === `${ELECTRON_SCHEME}:`) {
+    return (
+      u.hostname.toLowerCase() === "superhuman.com" &&
+      u.pathname === "/background_page.html"
+    );
+  }
+
+  // A packaged build may serve it from its install dir; forging file:// needs
+  // local filesystem access, by which point the credential store is readable.
+  if (u.protocol === "file:") return /superhuman/i.test(url);
+
+  // Otherwise the host must genuinely be ours. Electron ranks FIRST, so an
+  // impostor here beats the real tab and gets the credential read pointed at it.
   return hostMatches(url, "superhuman.com");
 }
 
@@ -84,6 +108,9 @@ function electronLaunchHint(port: number, platform: string = process.platform): 
         : "superhuman"; // Linux: no desktop app ships today; the extension is the route
   return `${bin} --remote-debugging-port=${port}`;
 }
+
+/** The desktop app's own URL scheme — nothing else can register it. */
+const ELECTRON_SCHEME = "superhuman-app";
 
 /** Where the web app lives, for error text. */
 const WEB_APP_URL = "https://mail.superhuman.com";

--- a/src/session-refresh.ts
+++ b/src/session-refresh.ts
@@ -45,7 +45,8 @@
  * Discovered 2026-07-16 — see docs/investigations/2026-07-16_attachment_download_401.md
  */
 import CDP from "chrome-remote-interface";
-import { getCDPHost, getCDPPort } from "./superhuman-api";
+import { getCDPHost } from "./superhuman-api";
+import { discoverEndpoint } from "./cdp-endpoint";
 import type { TokenInfo } from "./token-api";
 
 const ACCOUNTS_HOST = "https://accounts.superhuman.com";
@@ -341,17 +342,32 @@ async function* readCookiesFromPageTargets(
  * Returns null when no browser is reachable or no Superhuman cookies exist.
  */
 export async function readSessionCookieHeader(
-  port = getCDPPort()
+  port?: number
 ): Promise<string | null> {
   const host = getCDPHost();
   const deadline = deadlineIn(cdpTimeoutMs());
 
+  // An explicit port is honoured; otherwise probe the desktop app, then Chrome.
+  // This module exists FOR the Chrome-extension deployment, yet used to default
+  // to the Electron port (9252) and only worked because callers happened to
+  // thread a resolved port down.
+  let resolved: number;
+  if (port !== undefined) {
+    resolved = port;
+  } else {
+    try {
+      resolved = (await discoverEndpoint()).port;
+    } catch {
+      return null; // no endpoint at all — caller keeps the stale token
+    }
+  }
+
   const fromBrowser = toCookieHeader(
-    (await readCookiesFromBrowserTarget(host, port, deadline)) ?? undefined
+    (await readCookiesFromBrowserTarget(host, resolved, deadline)) ?? undefined
   );
   if (fromBrowser) return fromBrowser;
 
-  for await (const cookies of readCookiesFromPageTargets(host, port, deadline)) {
+  for await (const cookies of readCookiesFromPageTargets(host, resolved, deadline)) {
     const header = toCookieHeader(cookies);
     if (header) return header;
   }
@@ -441,7 +457,7 @@ function withTimeout<T>(p: Promise<T>, what: string, ms = cdpTimeoutMs()): Promi
  * user to relaunch an app. False positives are possible when signed out.
  */
 export async function isSessionRefreshHealthy(
-  port = getCDPPort()
+  port?: number
 ): Promise<boolean> {
   return (await readSessionCookieHeader(port)) !== null;
 }
@@ -486,7 +502,7 @@ function jwtExpiryMs(token: string | undefined): number | undefined {
 export async function refreshViaSessionCookies(
   email: string,
   existing?: TokenInfo,
-  port = getCDPPort()
+  port?: number
 ): Promise<TokenInfo | null> {
   const cookieHeader = await readSessionCookieHeader(port);
   if (!cookieHeader) return null;
@@ -506,7 +522,7 @@ export async function refreshViaSessionCookies(
  */
 export async function refreshManyViaSessionCookies(
   entries: Array<{ email: string; existing?: TokenInfo }>,
-  port = getCDPPort()
+  port?: number
 ): Promise<TokenInfo[]> {
   if (entries.length === 0) return [];
 

--- a/src/session-refresh.ts
+++ b/src/session-refresh.ts
@@ -46,7 +46,7 @@
  */
 import CDP from "chrome-remote-interface";
 import { getCDPHost } from "./superhuman-api";
-import { discoverEndpoint } from "./cdp-endpoint";
+import { classifyTarget, discoverEndpoint } from "./cdp-endpoint";
 import type { TokenInfo } from "./token-api";
 
 const ACCOUNTS_HOST = "https://accounts.superhuman.com";
@@ -273,9 +273,11 @@ async function* readCookiesFromPageTargets(
 
   const pages = targets.filter((t: any) => t.type === "page");
   // Superhuman tabs first: most likely responsive and on the right profile.
+  // classifyTarget rather than a substring — an impostor host must not be
+  // promoted ahead of the genuine tab.
   const ordered = [
-    ...pages.filter((t: any) => t.url?.includes("superhuman.com")),
-    ...pages.filter((t: any) => !t.url?.includes("superhuman.com")),
+    ...pages.filter((t: any) => classifyTarget(t) !== null),
+    ...pages.filter((t: any) => classifyTarget(t) === null),
   ];
 
   for (const target of ordered) {

--- a/src/superhuman-api.ts
+++ b/src/superhuman-api.ts
@@ -175,6 +175,24 @@ export async function disconnect(conn: SuperhumanConnection): Promise<void> {
 
 const SUPERHUMAN_EXTENSION_ID = "dcgcnpooblobhncpnddnhoendgbnglpn";
 
+/**
+ * Is this target the Superhuman extension's service worker?
+ *
+ * The ID must be the exact HOST of a chrome-extension: URL. A substring test
+ * accepts any site serving a worker whose URL merely contains the ID — e.g.
+ * https://evil.example/dcgcnpooblobhncpnddnhoendgbnglpn/sw.js — and both
+ * extension paths then attach and run token/account extraction inside it.
+ */
+function isSuperhumanExtensionWorker(t: any): boolean {
+  if (t?.type !== "service_worker" || !t.url) return false;
+  try {
+    const u = new URL(t.url);
+    return u.protocol === "chrome-extension:" && u.hostname === SUPERHUMAN_EXTENSION_ID;
+  } catch {
+    return false;
+  }
+}
+
 export interface ChromeExtConnection {
   swClient: CDP.Client;
   mainClient: CDP.Client;
@@ -187,13 +205,7 @@ export async function findChromeExtension(port: number): Promise<any | null> {
   try {
     const host = getCDPHost();
     const targets = await CDP.List({ host, port });
-    return (
-      targets.find(
-        (t: any) =>
-          t.url.includes(SUPERHUMAN_EXTENSION_ID) &&
-          t.type === "service_worker"
-      ) ?? null
-    );
+    return targets.find(isSuperhumanExtensionWorker) ?? null;
   } catch {
     return null;
   }
@@ -210,11 +222,7 @@ export async function connectToSuperhumanChrome(
     const host = getCDPHost();
     const targets = await CDP.List({ host, port });
 
-    const sw = targets.find(
-      (t: any) =>
-        t.url.includes(SUPERHUMAN_EXTENSION_ID) &&
-        t.type === "service_worker"
-    );
+    const sw = targets.find(isSuperhumanExtensionWorker);
     // The page we attach to and run credential-reading code in — the one place
     // a forged host would do real damage. classifyTarget verifies the hostname.
     const mainPage = targets.find((t: any) => classifyTarget(t) === "chrome");

--- a/src/superhuman-api.ts
+++ b/src/superhuman-api.ts
@@ -6,6 +6,7 @@
  */
 
 import CDP from "chrome-remote-interface";
+import { cdpPortCandidates, discoverEndpoint, noTargetHint } from "./cdp-endpoint";
 
 export interface SuperhumanConnection {
   client: CDP.Client;
@@ -36,17 +37,6 @@ export function getCDPPort(): number {
 }
 
 /**
- * Candidate CDP ports to probe when CDP_PORT isn't explicitly set.
- * 9252 = the Superhuman desktop (Electron) app — the one exposing
- * `background_page.html`, so it's tried first; 9250 = legacy Chrome-tab mode
- * (extension service worker); 9222 = generic Chromium default.
- */
-const CDP_PORT_CANDIDATES = [9252, 9250, 9222];
-
-// Cache the discovered port for the process lifetime to avoid re-probing.
-let discoveredPort: number | null = null;
-
-/**
  * Resolve the CDP port that actually hosts a Superhuman target.
  *
  * An explicit `CDP_PORT` env var always wins. Otherwise probe the candidate
@@ -59,42 +49,28 @@ let discoveredPort: number | null = null;
  * non-default port (e.g. the desktop app on 9252).
  */
 export async function discoverSuperhumanPort(): Promise<number> {
-  if (process.env.CDP_PORT) return parseInt(process.env.CDP_PORT, 10);
-  if (discoveredPort !== null) return discoveredPort;
-
-  const host = getCDPHost();
-  let pageFallback: number | null = null;
-
-  for (const port of CDP_PORT_CANDIDATES) {
-    let targets: any[];
-    try {
-      targets = await CDP.List({ host, port });
-    } catch {
-      continue; // port not listening
-    }
-    const hasBgPage = targets.some(
-      (t: any) =>
-        t.type === "page" &&
-        t.url.includes("background_page.html") &&
-        t.url.includes("superhuman")
-    );
-    if (hasBgPage) {
-      discoveredPort = port;
-      return port;
-    }
-    if (
-      pageFallback === null &&
-      targets.some(
-        (t: any) => t.type === "page" && t.url.includes("mail.superhuman.com")
-      )
-    ) {
-      pageFallback = port;
-    }
+  // Delegates to the shared discovery so there is exactly ONE implementation of
+  // "find the endpoint": same candidates, same ELECTRON_CDP_PORT/CHROME_CDP_PORT
+  // overrides, same skip-a-port-serving-something-else rule.
+  //
+  // There used to be two. This one probed a fixed [9252, 9250, 9222] and ignored
+  // the env overrides entirely, and because token-api's refresh paths call it
+  // FIRST and thread the result into readSessionCookieHeader — which treats a
+  // supplied port as authoritative — the legacy answer always won. With
+  // CHROME_CDP_PORT=9333 and nothing on the fixed candidates, refresh passed
+  // 9252, read no cookies, kept the stale token, and the 401 it exists to fix
+  // came back.
+  //
+  // Falls back to getCDPPort() rather than throwing: callers rely on this
+  // returning a port, and a bad port fails later with a better message than a
+  // discovery exception here would give.
+  try {
+    return (await discoverEndpoint()).port;
+  } catch {
+    return getCDPPort();
   }
-
-  discoveredPort = pageFallback ?? getCDPPort();
-  return discoveredPort;
 }
+
 
 /**
  * Check if Superhuman is running with CDP enabled
@@ -118,13 +94,7 @@ export async function ensureSuperhuman(port = getCDPPort()): Promise<boolean> {
     return true;
   }
   const host = getCDPHost();
-  console.error(
-    `Superhuman not reachable at ${host}:${port}.\n` +
-    `Probed ports ${CDP_PORT_CANDIDATES.join(", ")} for a Superhuman target and found none.\n` +
-    `Launch the desktop app with remote debugging, e.g.:\n` +
-    `  /Applications/Superhuman.app/Contents/MacOS/Superhuman --remote-debugging-port=9252\n` +
-    `If it is running on a different port, pass --port <n> or set CDP_PORT.`
-  );
+  console.error(`Superhuman not reachable at ${host}:${port}.\n` + noTargetHint(cdpPortCandidates()));
   return false;
 }
 

--- a/src/superhuman-api.ts
+++ b/src/superhuman-api.ts
@@ -138,9 +138,11 @@ export async function connectToSuperhuman(
   // Returns null if no matching tab is open — caller should fall back to token-only path.
   let mainPage: any;
   if (accountEmail) {
-    mainPage = superhumanPages.find((t: any) =>
-      t.url.toLowerCase().includes(accountEmail.toLowerCase())
-    ) ?? null;
+    // Match the account's PATH SEGMENT, not any occurrence of the address.
+    // includes() let a different genuine Superhuman tab win whenever the email
+    // appeared in its query or fragment — and the caller then runs credential and
+    // account extraction in the wrong account's page.
+    mainPage = superhumanPages.find((t: any) => urlHasAccountSegment(t.url, accountEmail)) ?? null;
     if (!mainPage) return null;
   } else {
     mainPage = superhumanPages[0];
@@ -160,6 +162,20 @@ export async function connectToSuperhuman(
     Network: client.Network,
     Page: client.Page,
   };
+}
+
+/** Does this URL address `email` as a path segment (not merely mention it)? */
+function urlHasAccountSegment(url: string, email: string): boolean {
+  try {
+    const u = new URL(url);
+    const want = email.toLowerCase();
+    // Path only — never search/hash, which the caller does not control.
+    return u.pathname
+      .split("/")
+      .some((seg) => decodeURIComponent(seg).toLowerCase() === want);
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/src/superhuman-api.ts
+++ b/src/superhuman-api.ts
@@ -6,7 +6,7 @@
  */
 
 import CDP from "chrome-remote-interface";
-import { cdpPortCandidates, discoverEndpoint, noTargetHint } from "./cdp-endpoint";
+import { cdpPortCandidates, classifyTarget, discoverEndpoint, noTargetHint } from "./cdp-endpoint";
 
 export interface SuperhumanConnection {
   client: CDP.Client;
@@ -24,12 +24,12 @@ export function getCDPHost(): string {
 }
 
 /**
- * Get CDP port from environment or default to 9252.
- * Note: 9252 is the port the Superhuman desktop (Electron) app listens on —
- * it's what the `com.user.superhuman-cdp` LaunchAgent passes via
- * `--remote-debugging-port=9252`, and the only target exposing
- * `background_page.html` for token refresh. (9250 was the old Chrome-tab-mode
- * default and is often occupied by an unrelated Chrome instance.)
+ * Get CDP port from CDP_PORT, or the static 9252 default.
+ *
+ * Prefer discoverSuperhumanPort() — this is the last-resort fallback, not a
+ * probe. 9252 is the desktop app's port (what the `com.user.superhuman-cdp`
+ * LaunchAgent passes), so on a Chrome-extension deployment this default is
+ * simply wrong; only discovery finds the browser.
  */
 export function getCDPPort(): number {
   const envPort = process.env.CDP_PORT;
@@ -39,14 +39,13 @@ export function getCDPPort(): number {
 /**
  * Resolve the CDP port that actually hosts a Superhuman target.
  *
- * An explicit `CDP_PORT` env var always wins. Otherwise probe the candidate
- * ports and prefer one exposing the Electron `background_page.html` (required
- * for silent token refresh); fall back to any port with a `mail.superhuman.com`
- * page, then to the static default. Result is cached.
+ * An explicit `CDP_PORT` wins. Otherwise probe the desktop app's port, then the
+ * browser's — see cdp-endpoint.ts, which owns the candidates, the overrides and
+ * the caching.
  *
  * Reads use local SQLite and don't need this; it matters for CDP paths —
- * chiefly token refresh — which previously failed when the app ran on a
- * non-default port (e.g. the desktop app on 9252).
+ * chiefly token refresh — which failed when the app ran on a port the caller
+ * did not name.
  */
 export async function discoverSuperhumanPort(): Promise<number> {
   // Delegates to the shared discovery so there is exactly ONE implementation of
@@ -79,7 +78,9 @@ export async function isSuperhumanRunning(port = getCDPPort()): Promise<boolean>
   try {
     const host = getCDPHost();
     const targets = await CDP.List({ host, port });
-    return targets.some(t => t.url.includes("mail.superhuman.com"));
+    // classifyTarget, not a substring: mail.superhuman.com.evil.example must
+    // not make us report Superhuman as running.
+    return targets.some((t: any) => classifyTarget(t) !== null);
   } catch {
     return false;
   }
@@ -125,10 +126,9 @@ export async function connectToSuperhuman(
   // Prefer the page with an account path (e.g., /user@example.com) over the root page
   const superhumanPages = targets.filter(
     (t: any) =>
-      t.url.includes("mail.superhuman.com") &&
+      classifyTarget(t) === "chrome" &&
       !t.url.includes("background") &&
-      !t.url.includes("serviceworker") &&
-      t.type === "page"
+      !t.url.includes("serviceworker")
   );
 
   // Sort by URL length descending — pages with account paths are longer
@@ -215,10 +215,9 @@ export async function connectToSuperhumanChrome(
         t.url.includes(SUPERHUMAN_EXTENSION_ID) &&
         t.type === "service_worker"
     );
-    const mainPage = targets.find(
-      (t: any) =>
-        t.url.includes("mail.superhuman.com") && t.type === "page"
-    );
+    // The page we attach to and run credential-reading code in — the one place
+    // a forged host would do real damage. classifyTarget verifies the hostname.
+    const mainPage = targets.find((t: any) => classifyTarget(t) === "chrome");
 
     if (!sw || !mainPage) return null;
 


### PR DESCRIPTION
Makes both CLIs use **the same code** for the thing they both need: find the Electron app, else Chrome/Chromium.

## Why

`session-refresh.ts` exists **for** the Chrome-extension deployment, yet defaulted to `getCDPPort()` = **9252, the macOS Electron port**. It only worked because callers threaded a resolved port down. Called with no port — as its own signature invites — it silently returns `null`, and callers treat `null` as "keep the stale token". The module written to fix the stale-token 401 could reintroduce it.

Measured against released **v0.38.4** on Linux:

| | no `CDP_PORT` |
|---|---|
| v0.38.4 (released) | **`NULL`** → stale token |
| this branch | 5 cookies in 35ms |

The sibling had it worse: `morgen auth` failed outright with `✗ ECONNREFUSED` (see edwinhu/morgen-cli#11).

## The shape

New `src/cdp-endpoint.ts`, **byte-identical to morgen-cli's file of the same name below the PRODUCT BLOCK** — 176 lines, same exported API (`discoverEndpoint`, `rankTargets`, `classifyTarget`, `cdpPortCandidates`, `cdpTimeoutMs`, `withTimeout`, `noTargetHint`, `getCDPHost`, `resetEndpointCache`), same order, same comments.

```
├─ PRODUCT BLOCK   ◄── the ONLY difference: name, ports, matchers, launch hint
└─ everything else ◄── identical in both repos
```

The two deployments are different **CDP endpoints**, not different tabs on one endpoint. That was the modelling error underneath all of this.

## Ports

| var | meaning |
|---|---|
| `CDP_PORT` | explicit single port — wins outright, skips probing |
| `ELECTRON_CDP_PORT` | desktop app (default 9252) |
| `CHROME_CDP_PORT` | Chrome/Chromium (default 9222) |

**9250 dropped.** On this machine it is a headless Chrome for an unrelated tool — probing it could bind to a browser with no Superhuman session.

A port that is listening but serving something else is skipped, not accepted — reachable is not the same as ours.

## Verification

452 pass / 0 fail (matches main), `tsc --noEmit` clean. Live: `readSessionCookieHeader()` with no port returns 5 cookies in 35ms; `isSessionRefreshHealthy()` true; `doctor` healthy.

Electron (9252) remains unverified — no Superhuman.app here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZvrft29zMGgks5abHVtVK