### PR TITLE
fix: app-health's Electron fixture asserted a URL that does not exist

### DIFF
--- a/scripts/cdp-substrate-gate.sh
+++ b/scripts/cdp-substrate-gate.sh
@@ -157,8 +157,15 @@ export G2_CASES='[
 export G2_CASES=$(echo "$G2_CASES" | sed 's/"null"/null/g')
 if run_g2 "$MG" morgen; then note PASS "morgen classifier"; else note FAIL "morgen classifier"; fails=$((fails+1)); fi
 
-# superhuman: the REAL desktop scheme + the app page; role must stay mail.* only.
+# superhuman: the app's MEASURED targets (2026-07-17, port 9252) + impostors.
+# The real background page is the https one; superhuman-app://production/* are
+# the main window and tab strip and must NOT win a role. The
+# superhuman-app://superhuman.com case is a legacy shape never observed on the
+# shipping app — kept only as defensive cover (see isElectronTarget).
 export G2_CASES='[
+  ["superhuman-app://production/browserWindow.html",null],
+  ["superhuman-app://production/tabs.html",null],
+  ["superhuman-app://production/background_page.html",null],
   ["superhuman-app://superhuman.com/background_page.html","electron"],
   ["https://mail.superhuman.com/~backend/build/background_page.html","electron"],
   ["https://mail.superhuman.com/e@x.com/inbox","chrome"],

--- a/src/__tests__/app-health.test.ts
+++ b/src/__tests__/app-health.test.ts
@@ -26,18 +26,58 @@ function mockCDPList(targets: any[] | (() => never)) {
   });
 }
 
+/**
+ * The MEASURED target set of the shipping Superhuman.app.
+ *
+ * Captured live 2026-07-17 from /Applications/Superhuman.app relaunched with
+ * --remote-debugging-port=9252. These are every `type: "page"` target it
+ * exposed, verbatim. Do not "tidy" these URLs — they are a recording, not a
+ * design. The background page is served over HTTPS on mail.superhuman.com;
+ * the superhuman-app:// targets that DO exist are the main window and the tab
+ * strip, on hostname "production", and are NOT the background page.
+ *
+ * The previous fixture here asserted a background page at
+ * superhuman-app://superhuman.com/background_page.html. No such target exists,
+ * and none ever did (see cdp-endpoint.ts's superhuman-app:// branch comment).
+ */
+const REAL_APP_TARGETS = [
+  { type: "page", url: "superhuman-app://production/browserWindow.html", id: "win1" },
+  {
+    type: "page",
+    url: "https://mail.superhuman.com/eddyhu@gmail.com/inbox/other/thread/abc123",
+    id: "mail1",
+  },
+  { type: "page", url: "superhuman-app://production/tabs.html", id: "tabs1" },
+  {
+    type: "page",
+    url: "https://mail.superhuman.com/~backend/build/background_page.html",
+    id: "bg1",
+  },
+];
+
 describe("isBackgroundPageReachable", () => {
-  test("true when a Superhuman background_page target is present", async () => {
-    mockCDPList([
-      { type: "page", url: "https://mail.superhuman.com/eddyhu@gmail.com", id: "p1" },
-      {
-        type: "page",
-        url: "superhuman-app://superhuman.com/background_page.html",
-        id: "bg1",
-      },
-    ]);
+  test("true against the real app's measured target set", async () => {
+    mockCDPList(REAL_APP_TARGETS);
     const { isBackgroundPageReachable } = await import("../app-health");
     expect(await isBackgroundPageReachable(9999)).toBe(true);
+  });
+
+  test("the real background page ALONE is sufficient (it is the target that carries this)", async () => {
+    // Pinning which target actually satisfies the gate. If someone breaks the
+    // https/mail.superhuman.com branch, this fails — the test above would not,
+    // because it would still have three other targets to hide behind.
+    mockCDPList([REAL_APP_TARGETS[3]]);
+    const { isBackgroundPageReachable } = await import("../app-health");
+    expect(await isBackgroundPageReachable(9999)).toBe(true);
+  });
+
+  test("false when only the app's non-background-page targets are present", async () => {
+    // superhuman-app://production/{browserWindow,tabs}.html are the real app,
+    // but they are NOT the background page — silent refresh cannot run on them,
+    // so the gate must stay shut rather than promise a path that does not work.
+    mockCDPList([REAL_APP_TARGETS[0], REAL_APP_TARGETS[2]]);
+    const { isBackgroundPageReachable } = await import("../app-health");
+    expect(await isBackgroundPageReachable(9999)).toBe(false);
   });
 
   test("false when only a non-Superhuman Chromium answers (Dia/Obsidian)", async () => {

--- a/src/__tests__/cdp-endpoint-classify.test.ts
+++ b/src/__tests__/cdp-endpoint-classify.test.ts
@@ -32,14 +32,25 @@ describe("isElectronTarget apex-fallback regression", () => {
   });
 });
 
-describe("real Electron/web shapes must keep classifying (false negative is worse)", () => {
-  test("superhuman-app://superhuman.com/background_page.html -> electron", () => {
-    expect(
-      classifyTarget(page("superhuman-app://superhuman.com/background_page.html"))
-    ).toBe("electron");
+/**
+ * MEASURED, not assumed.
+ *
+ * Captured live 2026-07-17 from the shipping /Applications/Superhuman.app
+ * relaunched with --remote-debugging-port=9252. Every `type: "page"` target it
+ * exposed, with the classification each must receive. This table is a
+ * recording; if the app changes, re-measure and update it — do not adjust the
+ * classifier to make a guess here go green.
+ */
+describe("the real app's measured targets must classify correctly (false negative is worse)", () => {
+  test("superhuman-app://production/browserWindow.html -> null (main window, not the bg page)", () => {
+    expect(classifyTarget(page("superhuman-app://production/browserWindow.html"))).toBeNull();
   });
 
-  test("https://mail.superhuman.com/~backend/build/background_page.html -> electron", () => {
+  test("superhuman-app://production/tabs.html -> null (tab strip, not the bg page)", () => {
+    expect(classifyTarget(page("superhuman-app://production/tabs.html"))).toBeNull();
+  });
+
+  test("https://mail.superhuman.com/~backend/build/background_page.html -> electron (THE real background page)", () => {
     expect(
       classifyTarget(page("https://mail.superhuman.com/~backend/build/background_page.html"))
     ).toBe("electron");
@@ -47,5 +58,45 @@ describe("real Electron/web shapes must keep classifying (false negative is wors
 
   test("https://mail.superhuman.com/e@x.com/inbox -> chrome", () => {
     expect(classifyTarget(page("https://mail.superhuman.com/e@x.com/inbox"))).toBe("chrome");
+  });
+
+  test("the real background page outranks the app's other targets (electron ranks first)", () => {
+    const targets = [
+      page("superhuman-app://production/browserWindow.html"),
+      page("https://mail.superhuman.com/e@x.com/inbox/other/thread/abc123"),
+      page("superhuman-app://production/tabs.html"),
+      page("https://mail.superhuman.com/~backend/build/background_page.html"),
+    ];
+    const ranked = rankTargets(targets);
+    // Exactly two viable targets, bg page first; the window/tabs are not viable.
+    expect(ranked.map((r) => r.source)).toEqual(["electron", "chrome"]);
+    expect(ranked[0]!.target).toBe(targets[3]!);
+  });
+});
+
+/**
+ * The superhuman-app:// branch's own behaviour.
+ *
+ * The scheme is REAL (browserWindow.html / tabs.html above prove it), but no
+ * superhuman-app:// BACKGROUND PAGE has ever been observed. The branch is kept
+ * as defensive cover for a build that might serve one; these tests pin that it
+ * cannot be widened into an impostor hole while it sits there unused.
+ */
+describe("superhuman-app:// branch is narrow (unobserved shape, must stay hostile to impostors)", () => {
+  test("superhuman-app://evil.example/background_page.html -> null", () => {
+    expect(classifyTarget(page("superhuman-app://evil.example/background_page.html"))).toBeNull();
+  });
+
+  test("superhuman-app://superhuman.com/evil.html -> null (path must be the bg page)", () => {
+    expect(classifyTarget(page("superhuman-app://superhuman.com/evil.html"))).toBeNull();
+  });
+
+  test("superhuman-app://production/background_page.html -> null (NOT measured; not trusted)", () => {
+    // Deliberate: "production" is the real hostname for the window/tabs, so it
+    // is the tempting host to widen to. No background page has been observed on
+    // it, and guessing here would trust a shape nobody has seen. If a real app
+    // build ever serves this, MEASURE it, then change this test and the branch
+    // together.
+    expect(classifyTarget(page("superhuman-app://production/background_page.html"))).toBeNull();
   });
 });

--- a/src/cdp-endpoint.ts
+++ b/src/cdp-endpoint.ts
@@ -66,17 +66,41 @@ const DEFAULT_CHROME_PORT = 9222;
 function isElectronTarget(url: string): boolean {
   if (!url.includes("background_page.html")) return false;
 
-  // The desktop app serves its background page over its OWN scheme:
-  //   superhuman-app://superhuman.com/background_page.html
-  // Requiring http(s) rejected it outright — discovery skipped a healthy
-  // Electron endpoint and desktop token refresh broke. Nothing but the app can
-  // register this scheme, so an exact host+path check is the identity.
   let u: URL | null = null;
   try {
     u = new URL(url);
   } catch {
     return false;
   }
+
+  // MEASURED 2026-07-17, /Applications/Superhuman.app --remote-debugging-port=9252.
+  // The four `type: "page"` targets the shipping app exposed, verbatim:
+  //
+  //   superhuman-app://production/browserWindow.html                  -> null
+  //   https://mail.superhuman.com/…/inbox/other/thread/…              -> chrome
+  //   superhuman-app://production/tabs.html                           -> null
+  //   https://mail.superhuman.com/~backend/build/background_page.html -> electron
+  //
+  // So the REAL background page arrives over https on mail.superhuman.com and is
+  // caught by the hostMatches branch at the bottom of this function — NOT here.
+  // The superhuman-app:// scheme is real, but the targets using it are the main
+  // window and the tab strip, on hostname "production", and neither is a
+  // background page. No superhuman-app:// background page was observed.
+  //
+  // This branch has therefore never fired on the shipping app. It was added in
+  // 609dfb7 on the strength of this repo's own app-health fixture — a fixture
+  // that asserted superhuman-app://superhuman.com/background_page.html and was
+  // itself written from assumption, never from a measurement (a571d32). The
+  // fixture invented the shape; this branch was then built to satisfy the
+  // fixture. Nothing outside that loop has ever attested to it.
+  //
+  // It is KEPT, not deleted: one measurement of one build on one machine is thin
+  // evidence for "no build ever serves this", and a false negative here breaks
+  // desktop token refresh outright (the failure mode 609dfb7 was fixing). It
+  // costs one URL parse and, being an exact host+path equality, cannot widen
+  // into an impostor hole while it sits unused. If you ever see a real
+  // superhuman-app:// background page, MEASURE it and correct the host/path
+  // here — do not guess "production" because the window targets use it.
   if (u.protocol === `${ELECTRON_SCHEME}:`) {
     return (
       u.hostname.toLowerCase() === "superhuman.com" &&


### PR DESCRIPTION
The fixture claimed the desktop app's background page is `superhuman-app://superhuman.com/background_page.html`. **Measured against the real Mac app** on port 9252, the four live `type: "page"` targets are:

| url | classifyTarget |
|---|---|
| `superhuman-app://production/browserWindow.html` | `null` |
| `https://mail.superhuman.com/…/inbox/other/thread/…` | `chrome` |
| `superhuman-app://production/tabs.html` | `null` |
| `https://mail.superhuman.com/~backend/build/background_page.html` | **`electron`** |

The real background page is served over **https on mail.superhuman.com**. The `superhuman-app://` targets that exist have hostname **`production`** and are the window and tab strip — not the background page.

## The lineage is circular

- `a571d32` introduced the URL **in a test fixture**. Its message records real measurement ("2 background_page targets") but **never a URL** — the string was written from assumption.
- `609dfb7` then added the classifier branch, justifying it verbatim: *"the app serves its background page over its OWN scheme … **this repo's own app-health fixture says so**."*

The fixture invented the shape; the branch was built to satisfy the fixture. Nothing outside that loop ever attested to it.

## The fixture gave ZERO coverage of the real page

Not just documenting a fiction — proven by mutation: **breaking the https branch (which makes real desktop token refresh fail completely) leaves the OLD fixture green.** It would have let that regression ship.

The new fixture fails (2 fail), and includes a case pinning the real page *alone* as sufficient, so it cannot hide behind the other three targets.

## The branch is kept, not deleted

One measurement of one build is thin evidence for "no build ever served this", and a false negative here is precisely the breakage `609dfb7` existed to fix — that failure already happened once in this workstream. It is an exact host+path equality, so it cannot widen into an impostor hole while unused.

Its comment now records what was **measured** and the real provenance, and warns against guessing `production` as the host — that widening is untested, so there is a test pinning `superhuman-app://production/background_page.html` → `null`.

**No loosening.** Every impostor case still rejected; `rankTargets` still puts the real background page first.

## Verification

465 pass / 0 fail (baseline 458). `tsc --noEmit` 0. Substrate gate CLEAN. Shared section byte-identical with morgen-cli.

Left alone as out of scope: `CLAUDE.md` still describes the background page in terms implying the `superhuman-app://` shape — same false belief, in docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZvrft29zMGgks5abHVtVK