### PR TITLE
feat(outlook-web): agentic email via the live Outlook Web session (Superhuman replacement)

### DIFF
--- a/OUTLOOK_WEB_BACKEND_SPEC.md
+++ b/OUTLOOK_WEB_BACKEND_SPEC.md
@@ -1,0 +1,136 @@
+# Outlook Web (OWA) backend — implementation spec
+
+Goal: add an `outlook-web` backend to superhuman-cli so Microsoft (Exchange Online)
+accounts are driven agentically **without any new OAuth grant**, by piggybacking the
+already-authenticated Outlook Web session in the CDP browser (port 9222). This replaces
+Superhuman for the UVA mailbox after UVA revoked Superhuman's tenant app.
+
+Context: UVA requires admin consent for third-party mail apps (device-code test with the
+Thunderbird client id returns "need admin approval"). The ONLY no-consent path is the live
+OWA session's own first-party token. Feasibility is fully proven (read + write verified live).
+
+## Architecture decision
+
+There is **no clean verb-abstracting Provider interface** in this codebase. Verbs call
+`portalInvoke` / `backendFetch` / `runtimeEvaluate` on `SuperhumanProvider`, or branch on
+`token.isMicrosoft`. So we:
+
+1. Add `OutlookWebProvider implements ConnectionProvider` (sibling to `SuperhumanProvider`).
+   It carries the OWA email + an access-token getter, and exposes a single data primitive
+   `owaFetch(method, path, body?)` → Outlook REST. No portal/runtimeEvaluate needed for
+   verbs (REST is plain HTTPS + Bearer). CDP is used ONLY by the token broker.
+2. Route Microsoft accounts to it in `connection-provider.ts` `providerFromToken()`:
+   branch `if (token.isMicrosoft) return new OutlookWebProvider(email)` **before** the
+   `superhumanToken` check (the stale MS entry in tokens.json also has a dead superhumanToken).
+   Google accounts are untouched → still Superhuman.
+3. Per-verb: branch `if (provider instanceof OutlookWebProvider)` at the top of each verb
+   fn (mirrors the existing `instanceof SuperhumanProvider` / `isMicrosoft` pattern), calling
+   an `owa*` data function that returns the SAME JSON shape the Superhuman path returns.
+
+## Token broker — `src/owa-token.ts`
+
+Reads the OWA session's own access token from the page's MSAL localStorage cache via CDP.
+Uses `chrome-remote-interface` (already a dep). No network capture needed.
+
+- Attach: `CDP.List({host, port:9222})`, pick the `page` target whose url host matches
+  `outlook.cloud.microsoft` OR `outlook.office.com` (use `hostMatches` from cdp-endpoint.ts).
+- Read token: `Runtime.evaluate` a fn that enumerates `localStorage`, JSON.parses each value,
+  and returns the entry where `credentialType` starts with `"AccessToken"`, `target` includes
+  `https://outlook.office.com/Mail.ReadWrite`. Entry schema (verified):
+  ```
+  { credentialType:"AccessToken", secret:"<JWT>", cachedAt:"<unixsec>",
+    expiresOn:"<unixsec>", clientId:"9199bf20-a13f-4107-85dc-02114787ef48",
+    realm:"<tenant>", homeAccountId:"<oid>.<tenant>", target:"<space-sep scopes>",
+    tokenType:"Bearer" }
+  ```
+  Return `{ accessToken: secret, expiresOn: Number(expiresOn)*1000, upn }`.
+  Derive `upn`/email by decoding the JWT payload (`upn` claim) — do NOT trust homeAccountId for email.
+- Refresh: if `expiresOn` within 5 min of now (or past), `Page.reload` the OWA tab, wait for
+  load (~4s) + re-read; OWA's MSAL silently re-mints on bootstrap. If still stale, throw a clear
+  error telling the user to open/refresh Outlook Web in the browser.
+- Disk cache: `${HOME}/.config/superhuman-cli/owa-tokens.json`, `{ [email]: {accessToken, expiresOn, upn} }`.
+  In-memory + disk; validate exp with a 5-min buffer before returning; re-scrape on miss.
+- Export: `getOwaToken(email?): Promise<{accessToken:string, email:string, expiresOn:number}>`.
+
+## REST client — `src/outlook-rest-api.ts`
+
+Base: `https://outlook.office.com/api/v2.0/me`. Helper:
+```ts
+owaFetch(token, method, path, body?) // Authorization: Bearer, Content-Type application/json
+  -> parsed JSON; throw on !ok with status+body; handle 204 (no content) -> null
+```
+Odata: use `$select`, `$top`, `$skip`, `$filter`, `$search`, `$orderby`. Threads: Outlook groups
+by `ConversationId`; superhuman "thread" ≈ conversation. For inbox we list messages and can group
+by ConversationId (or list latest per conversation via `$orderby=ReceivedDateTime desc`).
+
+Per-verb data fns (return EXACT superhuman JSON shapes — see Output Contracts):
+
+- `owaListInbox(token, {limit, needsReply, label, withBody})` → `InboxThread[]`
+  GET `/mailfolders/inbox/messages?$top=&$select=Subject,From,ToRecipients,CcRecipients,ReceivedDateTime,BodyPreview,ConversationId,IsRead,Flag,Categories,InternetMessageId&$orderby=ReceivedDateTime desc`
+  Map: id=Id, subject=Subject, from={email,name} from From.EmailAddress, to/cc arrays,
+  date=ReceivedDateTime, snippet=BodyPreview, messageCount (count per ConversationId if grouping else 1),
+  labelIds: derive `["UNREAD"]` if !IsRead, `["STARRED"]` if Flag.FlagStatus==="Flagged", plus Categories,
+  isFromMe (From is the account), awaitingReply (=isFromMe? no: last msg not from me). withBody adds body (Body.Content) + latestMessage.
+- `owaSearch(token, query, {limit, withBody})` → `InboxThread[]` via `$search="query"` on messages.
+- `owaGetThread(token, id)` → `ThreadMessage[]` — resolve the message's ConversationId, then
+  GET `/messages?$filter=ConversationId eq '<cid>'&$orderby=ReceivedDateTime asc&$select=...,Body`.
+  Shape: {id,threadId=ConversationId,subject,from,to,cc,date,snippet=BodyPreview,body=Body.Content}.
+- `owaCreateDraft(token, {to,cc,bcc,subject,body,html})` → POST `/messages` (creates in Drafts). returns Id.
+- `owaReply(token, id, {body,html,all})` → POST `/messages/{id}/createReply` or `/createReplyAll`,
+  then PATCH the returned draft body, OR use `/reply` (send). For DRAFT semantics use createReply→returns draft.
+- `owaForward(token, id, {to,body})` → POST `/messages/{id}/createForward` → draft.
+- `owaSendDraft(token, draftId)` → POST `/messages/{draftId}/send` (204).
+- `owaSendNew(token, {to,cc,bcc,subject,body})` → POST `/sendmail` with {Message, SaveToSentItems:true} (202/204).
+- `owaArchive(token, ids[])` → POST `/messages/{id}/move` {DestinationId:"archive"} each. (archive is a well-known folder name)
+- `owaDelete(token, ids[])` → POST `/messages/{id}/move` {DestinationId:"deleteditems"} (trash) — NOT hard delete.
+- `owaMarkRead(token, id, read:boolean)` → PATCH `/messages/{id}` {IsRead:read}.
+- `owaFlag(token, id, on:boolean)` → PATCH `/messages/{id}` {Flag:{FlagStatus: on?"Flagged":"NotFlagged"}}. (star≈flag)
+- `owaListStarred(token, {limit})` → `StarredThread[]` GET `/messages?$filter=Flag/FlagStatus eq 'Flagged'`.
+- `owaListLabels(token)` → `Label[]` from GET `/messages?$select=Categories` distinct, OR the master
+  categories list GET `/master​categories` — NOTE: correct path is `/me/outlook/masterCategories` on GRAPH;
+  on Outlook REST v2.0 it 404s (verified). Use `/mailfolders` for folders as labels, or Categories. Map {id,name,type}.
+- `owaAddLabel/owaRemoveLabel(token, id, name)` → PATCH `/messages/{id}` {Categories:[...]}.
+- `owaSnooze*` → Outlook has no native snooze via REST; emulate with a Deferred/Postpone? If no clean
+  mapping, return "snooze not supported on outlook-web" (graceful). (Confirm during impl.)
+- `owaListEvents/create/update/delete/free` → `/calendarview?startDateTime=&endDateTime=`, `/events`,
+  `/getSchedule` (free/busy). Map to CalendarEvent shape.
+- `owaListAttachments(token, msgId)` → GET `/messages/{id}/attachments`. download → GET `.../attachments/{aid}/$value`.
+- `owaExportEml(token, id)` → GET `/messages/{id}/$value` (MIME) → write file.
+- `owaContacts(token, q)` → GET `/me/contacts?$search` or `/people` (People API) → {email,name,score}.
+- Snippets / ai: NOT supported on OWA → verbs print a clear "not available on outlook-web accounts".
+
+## Output contracts (match verbatim — from arch map §3)
+
+- InboxThread: `{id, subject, from:{email,name}, to?, cc?, date, snippet, labelIds:string[], messageCount, isFromMe, awaitingReply}` (+body,latestMessage with --with-body)
+- ThreadMessage: `{id, threadId, subject, from:{email,name}, to:[{email,name}], cc:[{email,name}], date, snippet, body?}`
+- StarredThread: `{id, subject?, from?:{email,name}, date?, snippet?, labelIds?}`
+- Label: `{id, name, type?}`  · Draft: `{id, subject, from:string, to:string[], cc:string[], bcc:string[], preview, timestamp, source:"native", threadId?}`
+- CalendarEvent: `{id, summary, description, start, end, location, attendees:string[], organizer, isAllDay, status, calendarId}`
+- Attachment: `{id, attachmentId, name, mimeType, extension, messageId, threadId, inline}`
+- Contact: `{email, name?, score?}`
+- Mutation verbs (reply/forward/send/archive/delete/mark/star add-remove/label add-remove/draft
+  create-update-send-delete/calendar delete): **text output only**, ignore --json. Match `{success,error?}` semantics.
+- Formatter: arrays → NDJSON (one JSON per line), single object → pretty. `--json/--stream/--ndjson` are aliases.
+
+## Files
+- NEW: `src/owa-token.ts`, `src/outlook-rest-api.ts`, `src/outlook-web-provider.ts`
+- EDIT: `src/connection-provider.ts` (route microsoft→OWA in providerFromToken; import OutlookWebProvider)
+- EDIT: verb modules to branch on `provider instanceof OutlookWebProvider`: inbox.ts, read.ts,
+  (search in cli.ts/inbox), archive.ts, read-status.ts, labels.ts, snooze.ts, calendar.ts,
+  attachments.ts, contacts.ts; compose path (cli.ts cmdSend/cmdReply + draft-api.ts) — branch on
+  token.isMicrosoft to route to owa send/draft fns; DraftService: add OutlookDraftProvider for `draft list`.
+- EDIT: cdp-endpoint.ts — add `isOutlookTarget(url)` (hostMatches outlook.cloud.microsoft / outlook.office.com)
+  and export a helper to find the OWA target (used by owa-token.ts).
+
+## Testing (bun test)
+Mirror `src/__tests__/inbox-backend.test.ts`: construct `OutlookWebProvider`, monkeypatch
+`owaFetch` with a mock returning raw OWA REST fixtures, call the verb fn, assert emitted objects
+match the exact field names above AND assert the REST path/method/body via mock.calls.
+Add `outlook-token.test.ts` (localStorage entry parsing), `outlook-rest-api.test.ts` (shape mapping),
+`outlook-web-provider.test.ts` (routing: microsoft→OWA). Keep google→Superhuman routing green.
+
+## Constraints
+- NEVER hard-delete mail (delete = move to Deleted Items).
+- NEVER send without the same confirmation semantics the CLI already enforces.
+- Do not regress the Google/Superhuman path — all existing tests must stay green.
+- Token/secret never logged.

--- a/src/__tests__/app-health.test.ts
+++ b/src/__tests__/app-health.test.ts
@@ -9,10 +9,25 @@
  * wrong is exactly what caused the recurring focus-steal: a false
  * "reachable" would let the caller assume the silent path works.
  */
-import { test, expect, describe, mock, afterEach } from "bun:test";
+import { test, expect, describe, mock, afterEach, afterAll } from "bun:test";
+import RealCDPDefault from "chrome-remote-interface";
+
+// Snapshot the REAL chrome-remote-interface export before any mock.module runs.
+// bun's mock.restore() does NOT revert mock.module — it mutates the module's
+// global bindings (see read-backend.test.ts / labels-list.test.ts) — so a
+// module mock left here leaks into later test files: attachment-e2e's
+// CDP({ port }) would resolve to the stub `{}` instead of throwing, so that
+// E2E suite stops skipping (its Superhuman port is down) and runs against a
+// mailbox that now routes to Outlook Web. Restore the real module when this
+// file's tests finish so downstream files see the unmocked import.
+const REAL_CRI = { default: RealCDPDefault };
 
 afterEach(() => {
   mock.restore();
+});
+
+afterAll(() => {
+  mock.module("chrome-remote-interface", () => REAL_CRI);
 });
 
 function mockCDPList(targets: any[] | (() => never)) {

--- a/src/__tests__/draft-native-api-path.test.ts
+++ b/src/__tests__/draft-native-api-path.test.ts
@@ -120,12 +120,15 @@ describe("CLI fallback path rejects provider API when provider is superhuman", (
   test("errors out instead of using provider API when no idToken/userId", async () => {
     // Create a token cache with accessToken but NO superhumanToken/userId
     // This simulates the bug scenario: user has a cached token from the
-    // provider but hasn't run account auth to get Superhuman native creds
+    // provider but hasn't run account auth to get Superhuman native creds.
+    // NOTE: uses a GOOGLE account — Microsoft accounts now route to the
+    // Outlook Web backend (see outlook-web routing tests), so this
+    // superhuman-path regression is asserted on the Google/Superhuman path.
     const tokensData = {
       version: 1,
       accounts: {
-        "testuser@outlook.com": {
-          type: "microsoft" as const,
+        "testuser@gmail.com": {
+          type: "google" as const,
           accessToken: "fake-access-token",
           expires: Date.now() + 3600000,
           // NOTE: no superhumanToken, no userId — this is the bug trigger
@@ -171,12 +174,14 @@ describe("CLI fallback path rejects provider API when provider is superhuman", (
   });
 
   test("uses native API when idToken and userId are present", async () => {
-    // Create a token cache WITH superhumanToken and userId
+    // Create a token cache WITH superhumanToken and userId.
+    // Uses a GOOGLE account: Microsoft accounts now route to Outlook Web, so
+    // the native-Superhuman-path assertion is exercised via the Google path.
     const tokensData = {
       version: 1,
       accounts: {
-        "testuser@outlook.com": {
-          type: "microsoft" as const,
+        "testuser@gmail.com": {
+          type: "google" as const,
           accessToken: "fake-access-token",
           expires: Date.now() + 3600000,
           userId: "fake-user-id",

--- a/src/__tests__/outlook-rest-api.test.ts
+++ b/src/__tests__/outlook-rest-api.test.ts
@@ -1,0 +1,429 @@
+/**
+ * Tests for outlook-rest-api.ts — the Outlook REST v2.0 data functions.
+ *
+ * Each data function takes an injectable `OwaFetcher`. We supply a mock that
+ * records (method, path, body) and returns raw OWA REST fixtures, then assert
+ * BOTH the emitted superhuman shape AND the REST path/method/body issued.
+ */
+
+import { test, expect, describe, mock } from "bun:test";
+import {
+  owaListInbox,
+  owaSearch,
+  owaGetThread,
+  owaCreateDraft,
+  owaReply,
+  owaForward,
+  owaSendDraft,
+  owaSendNew,
+  owaArchive,
+  owaDelete,
+  owaMarkRead,
+  owaFlag,
+  owaListStarred,
+  owaListLabels,
+  owaAddLabel,
+  owaRemoveLabel,
+  owaListEvents,
+  owaListAttachments,
+  owaContacts,
+  owaListDrafts,
+  type OwaFetcher,
+} from "../outlook-rest-api";
+
+const ME = "ehu@law.virginia.edu";
+
+/** A recording fetcher whose responses are keyed by "METHOD path-prefix". */
+function makeFetcher(handler: (method: string, path: string, body?: any) => any) {
+  const calls: Array<{ method: string; path: string; body?: any }> = [];
+  const fn: OwaFetcher = mock(async (method: string, path: string, body?: any) => {
+    calls.push({ method, path, body });
+    return handler(method, path, body);
+  });
+  return { fn, calls };
+}
+
+/** A raw OWA message fixture. */
+function owaMessage(over: Record<string, any> = {}) {
+  return {
+    Id: "AAMkAGmsg1",
+    Subject: "Hello there",
+    From: { EmailAddress: { Name: "Alice", Address: "alice@x.com" } },
+    ToRecipients: [{ EmailAddress: { Name: "Me", Address: ME } }],
+    CcRecipients: [{ EmailAddress: { Name: "Bob", Address: "bob@x.com" } }],
+    ReceivedDateTime: "2026-07-19T12:00:00Z",
+    BodyPreview: "preview text",
+    ConversationId: "CONV1",
+    IsRead: false,
+    Flag: { FlagStatus: "NotFlagged" },
+    Categories: ["Work"],
+    InternetMessageId: "<abc@x.com>",
+    ...over,
+  };
+}
+
+describe("owaListInbox", () => {
+  test("maps messages to InboxThread and hits the inbox messages path", async () => {
+    const { fn, calls } = makeFetcher(() => ({ value: [owaMessage()] }));
+
+    const threads = await owaListInbox(fn, ME, { limit: 5 });
+
+    expect(calls[0]!.method).toBe("GET");
+    expect(calls[0]!.path).toContain("/mailfolders/inbox/messages");
+    expect(calls[0]!.path).toContain("$top=5");
+    expect(calls[0]!.path).toContain("ReceivedDateTime%20desc");
+
+    expect(threads).toHaveLength(1);
+    const t = threads[0]!;
+    expect(t.id).toBe("AAMkAGmsg1");
+    expect(t.subject).toBe("Hello there");
+    expect(t.from).toEqual({ email: "alice@x.com", name: "Alice" });
+    expect(t.to).toEqual([{ email: ME, name: "Me" }]);
+    expect(t.cc).toEqual([{ email: "bob@x.com", name: "Bob" }]);
+    expect(t.date).toBe("2026-07-19T12:00:00Z");
+    expect(t.snippet).toBe("preview text");
+    expect(t.messageCount).toBe(1);
+    // Unread + a category → UNREAD label + the category; not flagged → no STARRED.
+    expect(t.labelIds).toEqual(["UNREAD", "Work"]);
+    expect(t.isFromMe).toBe(false);
+    expect(t.awaitingReply).toBe(true);
+  });
+
+  test("isFromMe true when From is the account; STARRED label when flagged", async () => {
+    const { fn } = makeFetcher(() => ({
+      value: [
+        owaMessage({
+          From: { EmailAddress: { Name: "Me", Address: ME } },
+          IsRead: true,
+          Flag: { FlagStatus: "Flagged" },
+          Categories: [],
+        }),
+      ],
+    }));
+    const threads = await owaListInbox(fn, ME, {});
+    expect(threads[0]!.isFromMe).toBe(true);
+    expect(threads[0]!.awaitingReply).toBe(false);
+    expect(threads[0]!.labelIds).toEqual(["STARRED"]);
+  });
+
+  test("needsReply filters out messages the account sent", async () => {
+    const { fn } = makeFetcher(() => ({
+      value: [
+        owaMessage({ Id: "m-them", From: { EmailAddress: { Address: "them@x.com" } } }),
+        owaMessage({ Id: "m-me", From: { EmailAddress: { Address: ME } } }),
+      ],
+    }));
+    const threads = await owaListInbox(fn, ME, { needsReply: true });
+    expect(threads.map((t) => t.id)).toEqual(["m-them"]);
+  });
+
+  test("withBody adds Body to $select and populates body", async () => {
+    const { fn, calls } = makeFetcher(() => ({
+      value: [owaMessage({ Body: { ContentType: "HTML", Content: "<p>hi</p>" } })],
+    }));
+    const threads = await owaListInbox(fn, ME, { withBody: true });
+    expect(decodeURIComponent(calls[0]!.path)).toContain("Body");
+    expect((threads[0] as any).body).toBe("<p>hi</p>");
+  });
+});
+
+describe("owaSearch", () => {
+  test("issues a $search query and maps results", async () => {
+    const { fn, calls } = makeFetcher(() => ({ value: [owaMessage()] }));
+    const res = await owaSearch(fn, ME, "invoice", { limit: 3 });
+    expect(calls[0]!.path).toContain("/messages?");
+    expect(decodeURIComponent(calls[0]!.path)).toContain('$search="invoice"');
+    expect(res[0]!.subject).toBe("Hello there");
+  });
+});
+
+describe("owaGetThread", () => {
+  test("resolves ConversationId then lists the conversation oldest-first", async () => {
+    const { fn, calls } = makeFetcher((method, path) => {
+      if (path.includes("$select=ConversationId") && !path.includes("filter")) {
+        return { ConversationId: "CONV9" };
+      }
+      return {
+        value: [
+          owaMessage({ Id: "m1", ConversationId: "CONV9", Body: { Content: "first" } }),
+          owaMessage({ Id: "m2", ConversationId: "CONV9", Body: { Content: "second" } }),
+        ],
+      };
+    });
+
+    const msgs = await owaGetThread(fn, "AAMkAGmsg1");
+
+    // First call resolves the conversation id; second filters by it.
+    expect(calls[0]!.path).toContain("/messages/AAMkAGmsg1");
+    expect(decodeURIComponent(calls[1]!.path)).toContain("ConversationId eq 'CONV9'");
+    // No $orderby with $filter (Exchange InefficientFilter); sorted client-side.
+    expect(calls[1]!.path).not.toContain("orderby");
+
+    expect(msgs).toHaveLength(2);
+    expect(msgs[0]!.id).toBe("m1");
+    expect(msgs[0]!.threadId).toBe("CONV9");
+    expect(msgs[0]!.body).toBe("first");
+    expect(msgs[1]!.body).toBe("second");
+  });
+});
+
+describe("owaCreateDraft", () => {
+  test("POSTs /messages with recipient + body and returns the id", async () => {
+    const { fn, calls } = makeFetcher(() => ({ Id: "draftAA", ConversationId: "cX" }));
+    const res = await owaCreateDraft(fn, {
+      to: ["Carol <carol@x.com>"],
+      cc: ["dave@x.com"],
+      subject: "Hi",
+      body: "<p>body</p>",
+      html: true,
+    });
+    expect(calls[0]!.method).toBe("POST");
+    expect(calls[0]!.path).toBe("/messages");
+    const body = calls[0]!.body;
+    expect(body.Subject).toBe("Hi");
+    expect(body.Body).toEqual({ ContentType: "HTML", Content: "<p>body</p>" });
+    expect(body.ToRecipients).toEqual([
+      { EmailAddress: { Name: "Carol", Address: "carol@x.com" } },
+    ]);
+    expect(body.CcRecipients).toEqual([{ EmailAddress: { Address: "dave@x.com" } }]);
+    expect(res).toEqual({ id: "draftAA", threadId: "cX" });
+  });
+});
+
+describe("owaReply", () => {
+  test("createReply then PATCH body prepended above the quote", async () => {
+    const { fn, calls } = makeFetcher((method, path) => {
+      if (path.endsWith("/createReply")) {
+        return { Id: "reply1", ConversationId: "cc", Body: { Content: "<quote>" } };
+      }
+      return null;
+    });
+    const res = await owaReply(fn, "msgX", { body: "my reply", html: true, all: false });
+    expect(calls[0]!.path).toBe("/messages/msgX/createReply");
+    expect(calls[1]!.method).toBe("PATCH");
+    expect(calls[1]!.path).toBe("/messages/reply1");
+    expect(calls[1]!.body.Body.Content).toBe("my reply<br><br><quote>");
+    expect(res.id).toBe("reply1");
+  });
+
+  test("all:true uses createReplyAll", async () => {
+    const { fn, calls } = makeFetcher(() => ({ Id: "r2", Body: { Content: "" } }));
+    await owaReply(fn, "msgX", { body: "hi", all: true });
+    expect(calls[0]!.path).toBe("/messages/msgX/createReplyAll");
+  });
+});
+
+describe("owaForward", () => {
+  test("createForward then PATCH recipients + body", async () => {
+    const { fn, calls } = makeFetcher((method, path) => {
+      if (path.endsWith("/createForward")) return { Id: "fwd1", Body: { Content: "<orig>" } };
+      return null;
+    });
+    await owaForward(fn, "msgX", { to: ["z@x.com"], body: "fyi", html: true });
+    expect(calls[0]!.path).toBe("/messages/msgX/createForward");
+    expect(calls[1]!.method).toBe("PATCH");
+    expect(calls[1]!.body.ToRecipients).toEqual([{ EmailAddress: { Address: "z@x.com" } }]);
+    expect(calls[1]!.body.Body.Content).toBe("fyi<br><br><orig>");
+  });
+});
+
+describe("owaSendDraft / owaSendNew", () => {
+  test("owaSendDraft POSTs /send", async () => {
+    const { fn, calls } = makeFetcher(() => null);
+    await owaSendDraft(fn, "draftAA");
+    expect(calls[0]!.method).toBe("POST");
+    expect(calls[0]!.path).toBe("/messages/draftAA/send");
+  });
+
+  test("owaSendNew POSTs /sendmail with SaveToSentItems", async () => {
+    const { fn, calls } = makeFetcher(() => null);
+    await owaSendNew(fn, { to: ["a@x.com"], subject: "S", body: "B", html: true });
+    expect(calls[0]!.path).toBe("/sendmail");
+    expect(calls[0]!.body.SaveToSentItems).toBe(true);
+    expect(calls[0]!.body.Message.Subject).toBe("S");
+    expect(calls[0]!.body.Message.ToRecipients).toEqual([
+      { EmailAddress: { Address: "a@x.com" } },
+    ]);
+  });
+});
+
+describe("owaArchive / owaDelete (move, never hard delete)", () => {
+  test("archive moves to the archive folder", async () => {
+    const { fn, calls } = makeFetcher(() => null);
+    await owaArchive(fn, ["m1", "m2"]);
+    expect(calls).toHaveLength(2);
+    expect(calls[0]!.path).toBe("/messages/m1/move");
+    expect(calls[0]!.body).toEqual({ DestinationId: "archive" });
+  });
+
+  test("delete moves to deleteditems (trash), not a hard delete", async () => {
+    const { fn, calls } = makeFetcher(() => null);
+    await owaDelete(fn, ["m1"]);
+    expect(calls[0]!.path).toBe("/messages/m1/move");
+    expect(calls[0]!.body).toEqual({ DestinationId: "deleteditems" });
+  });
+});
+
+describe("owaMarkRead / owaFlag", () => {
+  test("markRead PATCHes IsRead", async () => {
+    const { fn, calls } = makeFetcher(() => null);
+    await owaMarkRead(fn, "m1", true);
+    expect(calls[0]!.method).toBe("PATCH");
+    expect(calls[0]!.body).toEqual({ IsRead: true });
+  });
+
+  test("flag PATCHes Flag.FlagStatus", async () => {
+    const { fn, calls } = makeFetcher(() => null);
+    await owaFlag(fn, "m1", true);
+    expect(calls[0]!.body).toEqual({ Flag: { FlagStatus: "Flagged" } });
+    await owaFlag(fn, "m1", false);
+    expect(calls[1]!.body).toEqual({ Flag: { FlagStatus: "NotFlagged" } });
+  });
+});
+
+describe("owaListStarred", () => {
+  test("filters on flagged and maps to StarredThread", async () => {
+    const { fn, calls } = makeFetcher(() => ({
+      value: [owaMessage({ Flag: { FlagStatus: "Flagged" } })],
+    }));
+    const res = await owaListStarred(fn, ME, { limit: 10 });
+    expect(decodeURIComponent(calls[0]!.path)).toContain("Flag/FlagStatus eq 'Flagged'");
+    expect(res[0]!.id).toBe("AAMkAGmsg1");
+    expect(res[0]!.subject).toBe("Hello there");
+    expect(res[0]!.from).toEqual({ email: "alice@x.com", name: "Alice" });
+  });
+});
+
+describe("owaListLabels / owaAddLabel / owaRemoveLabel", () => {
+  test("lists folders as labels", async () => {
+    const { fn, calls } = makeFetcher(() => ({
+      value: [{ Id: "F1", DisplayName: "Receipts" }],
+    }));
+    const labels = await owaListLabels(fn);
+    expect(calls[0]!.path).toContain("/mailfolders");
+    expect(labels).toEqual([{ id: "F1", name: "Receipts", type: "folder" }]);
+  });
+
+  test("addLabel merges into existing Categories", async () => {
+    const { fn, calls } = makeFetcher((method, path) => {
+      if (method === "GET") return { Categories: ["Old"] };
+      return null;
+    });
+    await owaAddLabel(fn, "m1", "New");
+    expect(calls[1]!.method).toBe("PATCH");
+    expect(calls[1]!.body).toEqual({ Categories: ["Old", "New"] });
+  });
+
+  test("removeLabel drops the category", async () => {
+    const { fn, calls } = makeFetcher((method) => {
+      if (method === "GET") return { Categories: ["Old", "New"] };
+      return null;
+    });
+    await owaRemoveLabel(fn, "m1", "Old");
+    expect(calls[1]!.body).toEqual({ Categories: ["New"] });
+  });
+});
+
+describe("owaListEvents", () => {
+  test("maps calendarview events to CalendarEvent", async () => {
+    const { fn, calls } = makeFetcher(() => ({
+      value: [
+        {
+          Id: "ev1",
+          Subject: "Faculty Lunch",
+          Body: { Content: "notes" },
+          Start: { DateTime: "2026-07-20T16:00:00", TimeZone: "UTC" },
+          End: { DateTime: "2026-07-20T17:00:00", TimeZone: "UTC" },
+          Location: { DisplayName: "Room 1" },
+          Attendees: [{ EmailAddress: { Address: "guest@x.com" } }],
+          Organizer: { EmailAddress: { Address: "org@x.com" } },
+          IsAllDay: false,
+          ShowAs: "Busy",
+        },
+      ],
+    }));
+    const events = await owaListEvents(fn, { timeMin: "A", timeMax: "B", limit: 5 });
+    expect(calls[0]!.path).toContain("/calendarview?");
+    const e = events[0]!;
+    expect(e).toEqual({
+      id: "ev1",
+      summary: "Faculty Lunch",
+      description: "notes",
+      start: "2026-07-20T16:00:00",
+      end: "2026-07-20T17:00:00",
+      location: "Room 1",
+      attendees: ["guest@x.com"],
+      organizer: "org@x.com",
+      isAllDay: false,
+      status: "Busy",
+      calendarId: "",
+    });
+  });
+});
+
+describe("owaListAttachments", () => {
+  test("maps non-inline attachments; drops inline", async () => {
+    const { fn, calls } = makeFetcher(() => ({
+      value: [
+        { Id: "att1", Name: "report.pdf", ContentType: "application/pdf", Size: 1000, IsInline: false },
+        { Id: "att2", Name: "logo.png", ContentType: "image/png", Size: 20, IsInline: true },
+      ],
+    }));
+    const atts = await owaListAttachments(fn, "msgX");
+    expect(calls[0]!.path).toContain("/messages/msgX/attachments");
+    expect(atts).toHaveLength(1);
+    expect(atts[0]).toEqual({
+      id: "att1",
+      attachmentId: "att1",
+      name: "report.pdf",
+      mimeType: "application/pdf",
+      extension: "pdf",
+      messageId: "msgX",
+      threadId: "msgX",
+      inline: false,
+    });
+  });
+});
+
+describe("owaContacts", () => {
+  test("substring-matches name/email and returns Contact shape", async () => {
+    const { fn } = makeFetcher(() => ({
+      value: [
+        { DisplayName: "Nadya Malenko", EmailAddresses: [{ Address: "malenko@bc.edu" }] },
+        { DisplayName: "Someone Else", EmailAddresses: [{ Address: "else@x.com" }] },
+      ],
+    }));
+    const contacts = await owaContacts(fn, "malenko");
+    expect(contacts).toEqual([{ email: "malenko@bc.edu", name: "Nadya Malenko" }]);
+  });
+});
+
+describe("owaListDrafts", () => {
+  test("maps drafts folder messages to the Draft contract", async () => {
+    const { fn, calls } = makeFetcher(() => ({
+      value: [
+        owaMessage({
+          Id: "d1",
+          Subject: "WIP",
+          From: { EmailAddress: { Name: "Me", Address: ME } },
+          ToRecipients: [{ EmailAddress: { Address: "x@x.com" } }],
+          CcRecipients: [],
+        }),
+      ],
+    }));
+    const drafts = await owaListDrafts(fn, 25);
+    expect(calls[0]!.path).toContain("/mailfolders/drafts/messages");
+    expect(drafts[0]).toEqual({
+      id: "d1",
+      subject: "WIP",
+      from: `Me <${ME}>`,
+      to: ["x@x.com"],
+      cc: [],
+      bcc: [],
+      preview: "preview text",
+      timestamp: "2026-07-19T12:00:00Z",
+      source: "native",
+      threadId: "CONV1",
+    });
+  });
+});

--- a/src/__tests__/outlook-token.test.ts
+++ b/src/__tests__/outlook-token.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for owa-token.ts — the disk-cache + freshness logic of the OWA token
+ * broker (the CDP scrape path is exercised live, not here).
+ *
+ * Isolated via SUPERHUMAN_CLI_CONFIG_DIR so the broker reads a temp dir, never
+ * the machine's real ~/.config/superhuman-cli/owa-tokens.json.
+ */
+
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getOwaToken, listOwaAccounts, clearOwaMemCacheForTest } from "../owa-token";
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "owa-token-test-"));
+  process.env.SUPERHUMAN_CLI_CONFIG_DIR = dir;
+  clearOwaMemCacheForTest();
+});
+
+afterEach(async () => {
+  delete process.env.SUPERHUMAN_CLI_CONFIG_DIR;
+  clearOwaMemCacheForTest();
+  await rm(dir, { recursive: true, force: true });
+});
+
+async function seed(map: Record<string, any>) {
+  await writeFile(join(dir, "owa-tokens.json"), JSON.stringify(map));
+}
+
+describe("listOwaAccounts", () => {
+  test("returns emails from the disk cache", async () => {
+    await seed({
+      "ehu@law.virginia.edu": {
+        accessToken: "tok",
+        email: "ehu@law.virginia.edu",
+        expiresOn: Date.now() + 3600_000,
+      },
+    });
+    expect(await listOwaAccounts()).toEqual(["ehu@law.virginia.edu"]);
+  });
+
+  test("empty when no cache file", async () => {
+    expect(await listOwaAccounts()).toEqual([]);
+  });
+});
+
+describe("getOwaToken (disk-cache hit)", () => {
+  test("returns a fresh cached token without touching CDP", async () => {
+    const expiresOn = Date.now() + 3600_000;
+    await seed({
+      "ehu@law.virginia.edu": {
+        accessToken: "fresh-token",
+        email: "ehu@law.virginia.edu",
+        expiresOn,
+      },
+    });
+    const tok = await getOwaToken("ehu@law.virginia.edu");
+    expect(tok.accessToken).toBe("fresh-token");
+    expect(tok.email).toBe("ehu@law.virginia.edu");
+    expect(tok.expiresOn).toBe(expiresOn);
+  });
+
+  test("no argument returns the only fresh account in the cache", async () => {
+    const expiresOn = Date.now() + 3600_000;
+    await seed({
+      "ehu@law.virginia.edu": {
+        accessToken: "t",
+        email: "ehu@law.virginia.edu",
+        expiresOn,
+      },
+    });
+    const tok = await getOwaToken();
+    expect(tok.email).toBe("ehu@law.virginia.edu");
+  });
+});

--- a/src/__tests__/outlook-token.test.ts
+++ b/src/__tests__/outlook-token.test.ts
@@ -14,6 +14,14 @@ import { getOwaToken, listOwaAccounts, clearOwaMemCacheForTest } from "../owa-to
 
 let dir: string;
 
+// HERMETIC: restore SUPERHUMAN_CLI_CONFIG_DIR to its prior value (not just
+// delete it) so this file never clobbers what a later-loaded test relies on.
+const HAD_CONFIG_DIR = Object.prototype.hasOwnProperty.call(
+  process.env,
+  "SUPERHUMAN_CLI_CONFIG_DIR"
+);
+const PRIOR_CONFIG_DIR = process.env.SUPERHUMAN_CLI_CONFIG_DIR;
+
 beforeEach(async () => {
   dir = await mkdtemp(join(tmpdir(), "owa-token-test-"));
   process.env.SUPERHUMAN_CLI_CONFIG_DIR = dir;
@@ -21,7 +29,8 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-  delete process.env.SUPERHUMAN_CLI_CONFIG_DIR;
+  if (HAD_CONFIG_DIR) process.env.SUPERHUMAN_CLI_CONFIG_DIR = PRIOR_CONFIG_DIR;
+  else delete process.env.SUPERHUMAN_CLI_CONFIG_DIR;
   clearOwaMemCacheForTest();
   await rm(dir, { recursive: true, force: true });
 });

--- a/src/__tests__/outlook-web-provider.test.ts
+++ b/src/__tests__/outlook-web-provider.test.ts
@@ -1,17 +1,19 @@
 /**
  * Tests for Microsoft -> Outlook Web routing and the OutlookWebProvider shim.
  *
- * SUPERHUMAN_CLI_CONFIG_DIR is set BEFORE importing so both the token cache
- * (token-api) and the OWA broker (owa-token) read an isolated temp dir.
+ * HERMETIC: SUPERHUMAN_CLI_CONFIG_DIR (read lazily by token-api AND owa-token)
+ * is set only for the duration of these tests and RESTORED to its prior value
+ * afterward, and the token-cache singleton is cleared after all tests. Setting
+ * it at module scope leaks into every later-loaded test file — it flipped the
+ * live attachment-e2e suite onto the wrong account. Do not do that.
  */
 
-import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import { test, expect, describe, beforeEach, afterEach, afterAll } from "bun:test";
 import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 const TEST_DIR = mkdtempSync(join(tmpdir(), "owa-provider-test-"));
-process.env.SUPERHUMAN_CLI_CONFIG_DIR = TEST_DIR;
 
 import { resolveProvider } from "../connection-provider";
 import { OutlookWebProvider } from "../outlook-web-provider";
@@ -22,6 +24,17 @@ import {
   type TokenInfo,
 } from "../token-api";
 import { clearOwaMemCacheForTest } from "../owa-token";
+
+const HAD_CONFIG_DIR = Object.prototype.hasOwnProperty.call(
+  process.env,
+  "SUPERHUMAN_CLI_CONFIG_DIR"
+);
+const PRIOR_CONFIG_DIR = process.env.SUPERHUMAN_CLI_CONFIG_DIR;
+
+function restoreConfigDir() {
+  if (HAD_CONFIG_DIR) process.env.SUPERHUMAN_CLI_CONFIG_DIR = PRIOR_CONFIG_DIR;
+  else delete process.env.SUPERHUMAN_CLI_CONFIG_DIR;
+}
 
 function seedOwaCache(map: Record<string, any>) {
   writeFileSync(join(TEST_DIR, "owa-tokens.json"), JSON.stringify(map));
@@ -34,6 +47,7 @@ function clearOwaCache() {
 }
 
 beforeEach(() => {
+  process.env.SUPERHUMAN_CLI_CONFIG_DIR = TEST_DIR;
   clearTokenCache();
   clearOwaMemCacheForTest();
   clearOwaCache();
@@ -43,6 +57,17 @@ afterEach(() => {
   clearTokenCache();
   clearOwaMemCacheForTest();
   clearOwaCache();
+  restoreConfigDir();
+});
+
+afterAll(() => {
+  // Leave the shared singletons + env exactly as later test files expect them.
+  clearTokenCache();
+  clearOwaMemCacheForTest();
+  restoreConfigDir();
+  try {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  } catch {}
 });
 
 describe("providerFromToken: Microsoft -> OutlookWebProvider", () => {

--- a/src/__tests__/outlook-web-provider.test.ts
+++ b/src/__tests__/outlook-web-provider.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for Microsoft -> Outlook Web routing and the OutlookWebProvider shim.
+ *
+ * SUPERHUMAN_CLI_CONFIG_DIR is set BEFORE importing so both the token cache
+ * (token-api) and the OWA broker (owa-token) read an isolated temp dir.
+ */
+
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const TEST_DIR = mkdtempSync(join(tmpdir(), "owa-provider-test-"));
+process.env.SUPERHUMAN_CLI_CONFIG_DIR = TEST_DIR;
+
+import { resolveProvider } from "../connection-provider";
+import { OutlookWebProvider } from "../outlook-web-provider";
+import { SuperhumanProvider } from "../superhuman-provider";
+import {
+  clearTokenCache,
+  setTokenCacheForTest,
+  type TokenInfo,
+} from "../token-api";
+import { clearOwaMemCacheForTest } from "../owa-token";
+
+function seedOwaCache(map: Record<string, any>) {
+  writeFileSync(join(TEST_DIR, "owa-tokens.json"), JSON.stringify(map));
+}
+
+function clearOwaCache() {
+  try {
+    rmSync(join(TEST_DIR, "owa-tokens.json"));
+  } catch {}
+}
+
+beforeEach(() => {
+  clearTokenCache();
+  clearOwaMemCacheForTest();
+  clearOwaCache();
+});
+
+afterEach(() => {
+  clearTokenCache();
+  clearOwaMemCacheForTest();
+  clearOwaCache();
+});
+
+describe("providerFromToken: Microsoft -> OutlookWebProvider", () => {
+  test("a microsoft cached token routes to OutlookWebProvider", async () => {
+    const token: TokenInfo = {
+      accessToken: "dead-oauth",
+      email: "ehu@law.virginia.edu",
+      expires: Date.now() + 3600_000,
+      isMicrosoft: true,
+    };
+    setTokenCacheForTest(token.email, token);
+
+    const provider = await resolveProvider({ account: "ehu@law.virginia.edu" });
+    expect(provider).toBeInstanceOf(OutlookWebProvider);
+  });
+
+  test("microsoft wins even when a (stale) superhumanToken is present", async () => {
+    const token: TokenInfo = {
+      accessToken: "dead-oauth",
+      email: "ehu@law.virginia.edu",
+      expires: Date.now() + 3600_000,
+      isMicrosoft: true,
+      superhumanToken: { token: "stale-dead-jwt", expires: Date.now() + 3600_000 },
+    };
+    setTokenCacheForTest(token.email, token);
+
+    const provider = await resolveProvider({ account: "ehu@law.virginia.edu" });
+    expect(provider).toBeInstanceOf(OutlookWebProvider);
+  });
+
+  test("a google token still routes to SuperhumanProvider (no regression)", async () => {
+    const token: TokenInfo = {
+      accessToken: "g-oauth",
+      email: "user@gmail.com",
+      expires: Date.now() + 3600_000,
+      isMicrosoft: false,
+      superhumanToken: { token: "sh-jwt", expires: Date.now() + 3600_000 },
+    };
+    setTokenCacheForTest(token.email, token);
+
+    const provider = await resolveProvider({ account: "user@gmail.com" });
+    expect(provider).toBeInstanceOf(SuperhumanProvider);
+  });
+});
+
+describe("resolveProvider: OWA broker fallback", () => {
+  test("surfaces a microsoft mailbox known only to the OWA broker", async () => {
+    // Not in the token cache; only the OWA broker knows it.
+    seedOwaCache({
+      "ehu@law.virginia.edu": {
+        accessToken: "owa-tok",
+        email: "ehu@law.virginia.edu",
+        expiresOn: Date.now() + 3600_000,
+      },
+    });
+    const provider = await resolveProvider({ account: "ehu@law.virginia.edu" });
+    expect(provider).toBeInstanceOf(OutlookWebProvider);
+  });
+
+  test("unknown account with no broker entry is null", async () => {
+    const provider = await resolveProvider({ account: "nobody@nowhere.com" });
+    expect(provider).toBeNull();
+  });
+});
+
+describe("OutlookWebProvider.getToken shim", () => {
+  test("returns a TokenInfo with the OWA access token and isOutlookWeb", async () => {
+    seedOwaCache({
+      "ehu@law.virginia.edu": {
+        accessToken: "owa-access-token",
+        email: "ehu@law.virginia.edu",
+        expiresOn: Date.now() + 3600_000,
+      },
+    });
+    const provider = new OutlookWebProvider("ehu@law.virginia.edu");
+    const token = await provider.getToken();
+    expect(token.accessToken).toBe("owa-access-token");
+    expect(token.email).toBe("ehu@law.virginia.edu");
+    expect(token.isMicrosoft).toBe(true);
+    expect(token.isOutlookWeb).toBe(true);
+  });
+
+  test("getAccountInfo reports the microsoft provider", async () => {
+    const provider = new OutlookWebProvider("ehu@law.virginia.edu");
+    const info = await provider.getAccountInfo();
+    expect(info).toEqual({
+      email: "ehu@law.virginia.edu",
+      isMicrosoft: true,
+      provider: "microsoft",
+    });
+  });
+});

--- a/src/attachments.ts
+++ b/src/attachments.ts
@@ -10,6 +10,13 @@
  */
 
 import type { ConnectionProvider } from "./connection-provider";
+import { OutlookWebProvider } from "./outlook-web-provider";
+import {
+  makeOwaFetcher,
+  owaListAttachments,
+  owaDownloadAttachment,
+  owaFetchRaw,
+} from "./outlook-rest-api";
 import { readThreadFromDB, listLocalAccounts } from "./sqlite-search";
 import { getCachedToken, loadTokensFromDisk } from "./token-api";
 
@@ -45,6 +52,8 @@ export interface AttachmentAuthOptions {
   accessToken: string;
   /** True for Microsoft/Outlook accounts, false for Gmail */
   isMicrosoft: boolean;
+  /** True when accessToken is an Outlook Web REST token (route to Outlook REST). */
+  isOutlookWeb?: boolean;
 }
 
 const MIME_TYPES: Record<string, string> = {
@@ -126,6 +135,12 @@ export async function listAttachments(
   threadId: string,
   accountEmail?: string
 ): Promise<Attachment[]> {
+  // Outlook Web: no local SQLite blob and the token is an Outlook REST token —
+  // list attachments straight from the message via Outlook REST.
+  if (_provider instanceof OutlookWebProvider) {
+    return owaListAttachments(_provider.fetcher(), threadId);
+  }
+
   // If no account email provided, fall back to empty list (can't query SQLite)
   if (!accountEmail) {
     return [];
@@ -346,7 +361,9 @@ export async function downloadAttachment(
     );
   }
 
-  if (auth.isMicrosoft) {
+  if (auth.isOutlookWeb) {
+    return owaDownloadAttachment(makeOwaFetcher(auth.accessToken), messageId, attachmentId);
+  } else if (auth.isMicrosoft) {
     return downloadAttachmentMsGraph(messageId, attachmentId, auth.accessToken);
   } else {
     return downloadAttachmentGmail(messageId, attachmentId, auth.accessToken);
@@ -443,6 +460,13 @@ export async function downloadRawMessage(
     throw new Error(
       "downloadRawMessage requires an OAuth access token. " +
       "Pass auth.accessToken from the cached token (token.accessToken)."
+    );
+  }
+
+  if (auth.isOutlookWeb) {
+    return owaFetchRaw(
+      auth.accessToken,
+      `/messages/${encodeURIComponent(messageId)}/$value`
     );
   }
 

--- a/src/attachments.ts
+++ b/src/attachments.ts
@@ -10,7 +10,13 @@
  */
 
 import type { ConnectionProvider } from "./connection-provider";
-import { OutlookWebProvider } from "./outlook-web-provider";
+// NOTE: OutlookWebProvider is imported LAZILY (dynamic import) inside
+// listAttachments — importing it statically pulls owa-token ->
+// chrome-remote-interface into this module's eager graph, which this file
+// shares with the live attachment-e2e suite. That extra binding interferes
+// with app-health.test.ts's chrome-remote-interface mock/restore and flips
+// attachment-e2e from "skip (no CDP)" into a hard failure. outlook-rest-api
+// itself is CDP-free (type-only imports), so its functions import statically.
 import {
   makeOwaFetcher,
   owaListAttachments,
@@ -136,7 +142,10 @@ export async function listAttachments(
   accountEmail?: string
 ): Promise<Attachment[]> {
   // Outlook Web: no local SQLite blob and the token is an Outlook REST token —
-  // list attachments straight from the message via Outlook REST.
+  // list attachments straight from the message via Outlook REST. Lazy import
+  // keeps owa-token/chrome-remote-interface out of this module's eager graph
+  // (see the import note at the top of this file).
+  const { OutlookWebProvider } = await import("./outlook-web-provider");
   if (_provider instanceof OutlookWebProvider) {
     return owaListAttachments(_provider.fetcher(), threadId);
   }

--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -6,6 +6,14 @@
 
 import type { ConnectionProvider } from "./connection-provider";
 import { SuperhumanProvider } from "./superhuman-provider";
+import { OutlookWebProvider } from "./outlook-web-provider";
+import {
+  owaListEvents,
+  owaCreateEvent,
+  owaUpdateEvent,
+  owaDeleteEvent,
+  owaFreeBusy,
+} from "./outlook-rest-api";
 import { getCachedTokenRaw } from "./token-api";
 
 /**
@@ -210,6 +218,13 @@ export async function listEvents(
   provider: ConnectionProvider,
   options?: ListEventsOptions
 ): Promise<CalendarEvent[]> {
+  if (provider instanceof OutlookWebProvider) {
+    return owaListEvents(provider.fetcher(), {
+      timeMin: options?.timeMin ? toISOString(options.timeMin) : undefined,
+      timeMax: options?.timeMax ? toISOString(options.timeMax) : undefined,
+      limit: options?.limit,
+    });
+  }
   // --- CDP / SuperhumanProvider path ---
   if (provider instanceof SuperhumanProvider && provider.hasPortal()) {
     try {
@@ -261,6 +276,21 @@ export async function createEvent(
   provider: ConnectionProvider,
   event: CreateEventInput
 ): Promise<CalendarResult> {
+  if (provider instanceof OutlookWebProvider) {
+    try {
+      const eventId = await owaCreateEvent(provider.fetcher(), {
+        summary: event.summary,
+        start: event.start,
+        end: event.end,
+        description: event.description,
+        location: event.location,
+        attendees: event.attendees,
+      });
+      return { success: true, eventId };
+    } catch (e: any) {
+      return { success: false, error: e.message };
+    }
+  }
   // --- CDP / SuperhumanProvider path ---
   if (provider instanceof SuperhumanProvider && provider.hasPortal()) {
     try {
@@ -322,6 +352,14 @@ export async function deleteEvent(
   eventId: string,
   calendarId?: string
 ): Promise<CalendarResult> {
+  if (provider instanceof OutlookWebProvider) {
+    try {
+      await owaDeleteEvent(provider.fetcher(), eventId);
+      return { success: true };
+    } catch (e: any) {
+      return { success: false, error: e.message };
+    }
+  }
   // --- CDP / SuperhumanProvider path ---
   if (provider instanceof SuperhumanProvider && provider.hasPortal()) {
     try {
@@ -352,6 +390,21 @@ export async function updateEvent(
   updates: UpdateEventInput,
   calendarId?: string
 ): Promise<CalendarResult> {
+  if (provider instanceof OutlookWebProvider) {
+    try {
+      await owaUpdateEvent(provider.fetcher(), eventId, {
+        summary: updates.summary,
+        start: updates.start,
+        end: updates.end,
+        description: updates.description,
+        location: updates.location,
+        attendees: updates.attendees,
+      });
+      return { success: true, eventId };
+    } catch (e: any) {
+      return { success: false, error: e.message };
+    }
+  }
   // --- CDP / SuperhumanProvider path ---
   if (provider instanceof SuperhumanProvider && provider.hasPortal()) {
     try {
@@ -410,6 +463,13 @@ export async function getFreeBusy(
   provider: ConnectionProvider,
   options: FreeBusyOptions
 ): Promise<FreeBusyResult> {
+  if (provider instanceof OutlookWebProvider) {
+    return owaFreeBusy(
+      provider.fetcher(),
+      toISOString(options.timeMin),
+      toISOString(options.timeMax)
+    );
+  }
   // --- CDP / SuperhumanProvider path ---
   if (provider instanceof SuperhumanProvider && provider.hasPortal()) {
     try {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -78,8 +78,20 @@ import { isBackgroundPageReachable, relaunchSuperhumanForCDP } from "./app-healt
 import type { ConnectionProvider } from "./connection-provider";
 import { CachedTokenProvider, CDPConnectionProvider, resolveProvider } from "./connection-provider";
 import { SuperhumanProvider } from "./superhuman-provider";
+import { OutlookWebProvider } from "./outlook-web-provider";
+import {
+  makeOwaFetcher,
+  owaCreateDraft,
+  owaReply,
+  owaForward,
+  owaSendDraft,
+  owaSendNew,
+  owaContacts,
+  owaListDrafts,
+} from "./outlook-rest-api";
 import { DraftService, type Draft } from "./services/draft-service";
 import { SuperhumanDraftProvider } from "./providers/superhuman-draft-provider";
+import { OutlookDraftProvider } from "./providers/outlook-draft-provider";
 
 const VERSION = "0.38.5";
 const CDP_PORT = parseInt(process.env.CDP_PORT || "9252", 10);
@@ -1162,6 +1174,227 @@ async function getProvider(options: CliOptions): Promise<ConnectionProvider> {
 }
 
 /**
+ * Resolve an OutlookWebProvider for `email` when that account is a Microsoft
+ * mailbox routed to the Outlook Web backend (either a `microsoft` entry in
+ * tokens.json or an account the OWA broker knows about). Returns null for
+ * Google/Superhuman accounts so the normal path runs unchanged.
+ */
+async function owaProviderFor(email?: string): Promise<OutlookWebProvider | null> {
+  try {
+    const provider = await resolveProvider({ account: email });
+    return provider instanceof OutlookWebProvider ? provider : null;
+  } catch {
+    return null;
+  }
+}
+
+/** A TokenInfo shim (accessToken + isOutlookWeb) for an OWA account, or null. */
+async function resolveOwaTokenInfo(email?: string): Promise<TokenInfo | null> {
+  const provider = await owaProviderFor(email);
+  if (!provider) return null;
+  try {
+    return await provider.getToken();
+  } catch (e) {
+    error(`Outlook Web: ${(e as Error).message}`);
+    process.exit(1);
+  }
+}
+
+/**
+ * Resolve the attachment/raw-message auth ({accessToken, isMicrosoft,
+ * isOutlookWeb}) for an account, preferring the Outlook Web token for Microsoft
+ * mailboxes and falling back to the cached Superhuman/OAuth token otherwise.
+ */
+async function attachmentAuthFor(
+  email?: string
+): Promise<{ accessToken: string; isMicrosoft: boolean; isOutlookWeb?: boolean } | undefined> {
+  const owa = await resolveOwaTokenInfo(email);
+  if (owa) {
+    return { accessToken: owa.accessToken, isMicrosoft: true, isOutlookWeb: true };
+  }
+  const token = await resolveToken(email);
+  return token
+    ? { accessToken: token.accessToken, isMicrosoft: token.isMicrosoft }
+    : undefined;
+}
+
+/** Print the reason a verb can't run on outlook-web and exit non-zero. */
+function owaUnsupported(verb: string): never {
+  error(`${verb} is not available on outlook-web accounts.`);
+  process.exit(1);
+}
+
+/** Parse recipient strings into Outlook-friendly "Name <email>" / bare list. */
+function owaRecipients(list: string[]): string[] {
+  return list.filter(Boolean);
+}
+
+// --- Outlook Web command handlers -----------------------------------------
+
+/** `send` on an OWA account: compose + send via Outlook REST (/sendmail). */
+async function cmdSendOwa(provider: OutlookWebProvider, options: CliOptions): Promise<void> {
+  if (options.attachFiles && options.attachFiles.length > 0) {
+    owaUnsupported("Sending with attachments");
+  }
+  const html = options.html || textToHtml(options.body);
+  try {
+    await owaSendNew(provider.fetcher(), {
+      to: owaRecipients(options.to),
+      cc: owaRecipients(options.cc),
+      bcc: owaRecipients(options.bcc),
+      subject: options.subject || "",
+      body: html,
+      html: true,
+    });
+  } catch (e) {
+    error(`Failed to send: ${(e as Error).message}`);
+    process.exit(1);
+  }
+  success("Email sent");
+  log(`  ${colors.dim}Account: ${await provider.getCurrentEmail()}${colors.reset}`);
+}
+
+/** Apply --to/--cc overrides to a freshly created reply/forward draft. */
+async function owaPatchRecipients(provider: OutlookWebProvider, draftId: string, options: CliOptions) {
+  const patch: any = {};
+  if (options.to.length > 0) {
+    patch.ToRecipients = owaRecipients(options.to).map((s) => {
+      const m = s.match(/^(.*?)\s*<([^<>]+)>\s*$/);
+      return m
+        ? { EmailAddress: { Name: m[1]!.trim() || undefined, Address: m[2]!.trim() } }
+        : { EmailAddress: { Address: s.trim() } };
+    });
+  }
+  if (options.cc.length > 0) {
+    patch.CcRecipients = owaRecipients(options.cc).map((s) => {
+      const m = s.match(/^(.*?)\s*<([^<>]+)>\s*$/);
+      return m
+        ? { EmailAddress: { Name: m[1]!.trim() || undefined, Address: m[2]!.trim() } }
+        : { EmailAddress: { Address: s.trim() } };
+    });
+  }
+  if (Object.keys(patch).length > 0) {
+    await provider.owaFetch("PATCH", `/messages/${encodeURIComponent(draftId)}`, patch);
+  }
+}
+
+/** `reply` / `reply-all` on an OWA account. */
+async function cmdReplyOwa(
+  provider: OutlookWebProvider,
+  options: CliOptions,
+  all: boolean
+): Promise<void> {
+  if (options.attachFiles && options.attachFiles.length > 0) {
+    owaUnsupported("Replying with attachments");
+  }
+  const html = options.html || textToHtml(options.body || "");
+  const fetcher = provider.fetcher();
+  try {
+    const draft = await owaReply(fetcher, options.threadId!, { body: html, html: true, all });
+    if (!draft.id) {
+      error("Failed to create reply draft");
+      process.exit(1);
+    }
+    await owaPatchRecipients(provider, draft.id, options);
+    if (options.send) {
+      await owaSendDraft(fetcher, draft.id);
+      success("Reply sent");
+    } else {
+      success("Reply draft created in Outlook");
+      log(`  ${colors.dim}Draft ID: ${draft.id}${colors.reset}`);
+    }
+    log(`  ${colors.dim}Account: ${await provider.getCurrentEmail()}${colors.reset}`);
+  } catch (e) {
+    error(`Failed to ${options.send ? "send reply" : "create reply draft"}: ${(e as Error).message}`);
+    process.exit(1);
+  }
+}
+
+/** `forward` on an OWA account. */
+async function cmdForwardOwa(provider: OutlookWebProvider, options: CliOptions): Promise<void> {
+  if (options.attachFiles && options.attachFiles.length > 0) {
+    owaUnsupported("Forwarding with attachments");
+  }
+  if (options.to.length === 0) {
+    error("Forward requires at least one recipient (--to)");
+    process.exit(1);
+  }
+  const html = options.html || textToHtml(options.body || "");
+  const fetcher = provider.fetcher();
+  try {
+    const draft = await owaForward(fetcher, options.threadId!, {
+      to: owaRecipients(options.to),
+      body: html,
+      html: true,
+    });
+    if (!draft.id) {
+      error("Failed to create forward draft");
+      process.exit(1);
+    }
+    if (options.send) {
+      await owaSendDraft(fetcher, draft.id);
+      success("Forward sent");
+    } else {
+      success("Forward draft created in Outlook");
+      log(`  ${colors.dim}Draft ID: ${draft.id}${colors.reset}`);
+    }
+    log(`  ${colors.dim}Account: ${await provider.getCurrentEmail()}${colors.reset}`);
+  } catch (e) {
+    error(`Failed to ${options.send ? "send forward" : "create forward draft"}: ${(e as Error).message}`);
+    process.exit(1);
+  }
+}
+
+/** `draft` create/update on an OWA account (create only; update falls back). */
+async function cmdDraftOwa(provider: OutlookWebProvider, options: CliOptions): Promise<void> {
+  const fetcher = provider.fetcher();
+  if (options.updateDraftId) {
+    // Merge-update a draft: PATCH the fields the user passed.
+    const patch: any = {};
+    if (options.subject) patch.Subject = options.subject;
+    if (options.html || options.body) {
+      patch.Body = { ContentType: "HTML", Content: options.html || textToHtml(options.body) };
+    }
+    if (options.to.length > 0 || options.cc.length > 0) {
+      await owaPatchRecipients(provider, options.updateDraftId, options);
+    }
+    try {
+      if (Object.keys(patch).length > 0) {
+        await provider.owaFetch("PATCH", `/messages/${encodeURIComponent(options.updateDraftId)}`, patch);
+      }
+      success("Draft updated in Outlook");
+      log(`  ${colors.dim}Draft ID: ${options.updateDraftId}${colors.reset}`);
+    } catch (e) {
+      error(`Failed to update draft: ${(e as Error).message}`);
+      process.exit(1);
+    }
+    return;
+  }
+
+  requireAnyRecipient(options);
+  if (options.attachFiles && options.attachFiles.length > 0) {
+    owaUnsupported("Draft attachments");
+  }
+  const html = options.html || textToHtml(options.body);
+  try {
+    const draft = await owaCreateDraft(fetcher, {
+      to: owaRecipients(options.to),
+      cc: owaRecipients(options.cc),
+      bcc: owaRecipients(options.bcc),
+      subject: options.subject || "",
+      body: html,
+      html: true,
+    });
+    success("Draft created in Outlook");
+    log(`  ${colors.dim}Draft ID: ${draft.id}${colors.reset}`);
+    log(`  ${colors.dim}Account: ${await provider.getCurrentEmail()}${colors.reset}`);
+  } catch (e) {
+    error(`Failed to create draft: ${(e as Error).message}`);
+    process.exit(1);
+  }
+}
+
+/**
  * Resolve all recipients via the local Superhuman contacts DB.
  * Names without @ are looked up in contacts; emails are passed through unchanged.
  * The provider argument is unused (kept for call-site compatibility) — contact
@@ -1507,6 +1740,7 @@ async function resolveBackendUserInfo(
 
 
 async function cmdSnippets(options: CliOptions) {
+  if (await owaProviderFor(options.account)) owaUnsupported("Snippets");
   const { userInfo } = await resolveBackendUserInfo(options);
   const snippets = await listSnippets(userInfo);
 
@@ -1644,6 +1878,9 @@ async function cmdSnippet(options: CliOptions) {
 
 
 async function cmdDraft(options: CliOptions) {
+  const owaProvider = await owaProviderFor(options.account);
+  if (owaProvider) return cmdDraftOwa(owaProvider, options);
+
   // If updating an existing draft
   if (options.updateDraftId) {
     const draftId = options.updateDraftId;
@@ -1922,6 +2159,21 @@ async function cmdDeleteDraft(options: CliOptions) {
     process.exit(1);
   }
 
+  const owaProvider = await owaProviderFor(options.account);
+  if (owaProvider) {
+    const draftProvider = new OutlookDraftProvider(owaProvider);
+    for (const draftId of draftIds) {
+      info(`Deleting Outlook draft ${draftId.slice(-15)}...`);
+      try {
+        await draftProvider.deleteDraft(draftId);
+        success(`Deleted Outlook draft ${draftId.slice(-15)}`);
+      } catch (e) {
+        error(`Failed to delete draft: ${(e as Error).message}`);
+      }
+    }
+    return;
+  }
+
   // Separate native drafts from provider drafts
   const nativeDraftIds = draftIds.filter(id => id.startsWith("draft00"));
   const providerDraftIds = draftIds.filter(id => !id.startsWith("draft00"));
@@ -1987,6 +2239,18 @@ async function cmdSendDraft(options: CliOptions) {
     error("Draft ID is required");
     error("Usage: superhuman draft send <draft-id> --account=<email> --to=<recipient> --subject=<subject> --body=<body>");
     process.exit(1);
+  }
+
+  const owaProvider = await owaProviderFor(options.account);
+  if (owaProvider) {
+    try {
+      await owaSendDraft(owaProvider.fetcher(), draftId);
+      success(`Draft ${draftId.slice(-15)} sent`);
+    } catch (e) {
+      error(`Failed to send draft: ${(e as Error).message}`);
+      process.exit(1);
+    }
+    return;
   }
 
   // Validate draft ID format
@@ -2172,20 +2436,28 @@ async function cmdListDrafts(options: CliOptions) {
   const filterTo = options.to.length > 0 ? options.to[0]!.toLowerCase() : "";
   const filterSubject = options.subject ? options.subject.toLowerCase() : "";
 
-  const token = await resolveToken(options.account);
-  if (!token) {
+  // Outlook Web accounts list drafts from the Outlook Drafts folder.
+  const owaProvider = await owaProviderFor(options.account);
+  const draftProvider = owaProvider
+    ? new OutlookDraftProvider(owaProvider)
+    : null;
+
+  const token = draftProvider ? null : await resolveToken(options.account);
+  if (!draftProvider && !token) {
     error("Could not resolve Superhuman credentials");
     process.exit(1);
   }
 
-  info(`Fetching drafts from ${token.email}...`);
+  const accountLabel = draftProvider
+    ? await owaProvider!.getCurrentEmail()
+    : token!.email;
+  info(`Fetching drafts from ${accountLabel}...`);
 
   try {
-    // Use Superhuman native draft provider only
-    const nativeProvider = new SuperhumanDraftProvider(token);
-
-    // Use DraftService to fetch drafts
-    const service = new DraftService([nativeProvider]);
+    // Native draft provider: Outlook (OWA) or Superhuman.
+    const service = new DraftService([
+      draftProvider ?? new SuperhumanDraftProvider(token!),
+    ]);
     let drafts = await service.listDrafts(limit, offset);
 
     // Apply --to filter
@@ -2208,7 +2480,7 @@ async function cmdListDrafts(options: CliOptions) {
     }
 
     if (drafts.length === 0) {
-      log(`${colors.dim}No drafts found in ${token.email}.${colors.reset}`);
+      log(`${colors.dim}No drafts found in ${accountLabel}.${colors.reset}`);
       return;
     }
 
@@ -2247,6 +2519,9 @@ async function cmdSend(options: CliOptions) {
   // `send` composes and sends a new email. To send an existing saved draft,
   // use `draft send <id>` (cmdSendDraft) — the single code path for that.
   requireAnyRecipient(options);
+
+  const owaProvider = await owaProviderFor(options.account);
+  if (owaProvider) return cmdSendOwa(owaProvider, options);
 
   // Native path: create a Superhuman draft, then send it via messages/send —
   // the same two-step flow as `draft create` + `draft send`, which is the
@@ -2874,6 +3149,9 @@ async function cmdReply(options: CliOptions) {
     process.exit(1);
   }
 
+  const owaProvider = await owaProviderFor(options.account);
+  if (owaProvider) return cmdReplyOwa(owaProvider, options, false);
+
   // Fast path: use cached Superhuman credentials (no CDP needed)
   {
     const token = await resolveToken(options.account);
@@ -3041,6 +3319,9 @@ async function cmdReplyAll(options: CliOptions) {
     process.exit(1);
   }
 
+  const owaProvider = await owaProviderFor(options.account);
+  if (owaProvider) return cmdReplyOwa(owaProvider, options, true);
+
   // Fast path: use cached Superhuman credentials (no CDP needed)
   {
     const token = await resolveToken(options.account);
@@ -3200,6 +3481,9 @@ async function cmdForward(options: CliOptions) {
     process.exit(1);
   }
 
+  const owaProvider = await owaProviderFor(options.account);
+  if (owaProvider) return cmdForwardOwa(owaProvider, options);
+
   // Fast path: use cached Superhuman credentials (no CDP needed)
   {
     const token = await resolveToken(options.account);
@@ -3356,6 +3640,12 @@ async function cmdForward(options: CliOptions) {
  * command, or exit. These ops are token-direct (no running app required).
  */
 async function requireToken(options: CliOptions) {
+  // Microsoft accounts route to the Outlook Web token (Outlook REST), which the
+  // mutation verbs (archive/delete/mark/label/star) understand via
+  // token.isOutlookWeb — no Superhuman credentials needed.
+  const owa = await resolveOwaTokenInfo(options.account);
+  if (owa) return owa;
+
   const token = await resolveToken(options.account);
   if (!token?.email || !(token.superhumanToken?.token || token.idToken || token.accessToken)) {
     error("Could not resolve Superhuman credentials. Run 'superhuman account auth'.");
@@ -3688,6 +3978,8 @@ async function cmdSnooze(options: CliOptions) {
     process.exit(1);
   }
 
+  if (await owaProviderFor(options.account)) owaUnsupported("Snooze");
+
   if (!options.snoozeUntil) {
     error("Snooze time is required (--until)");
     console.log(`Usage: superhuman snooze set <thread-id> --until <time>`);
@@ -3734,6 +4026,8 @@ async function cmdUnsnooze(options: CliOptions) {
     process.exit(1);
   }
 
+  if (await owaProviderFor(options.account)) owaUnsupported("Snooze");
+
   const token = await requireToken(options);
 
   let successCount = 0;
@@ -3758,6 +4052,8 @@ async function cmdUnsnooze(options: CliOptions) {
 }
 
 async function cmdSnoozed(options: CliOptions) {
+  if (await owaProviderFor(options.account)) owaUnsupported("Snooze");
+
   const token = await requireToken(options);
 
   const threads = await listSnoozed(token, options.limit);
@@ -3826,10 +4122,7 @@ async function cmdDownload(options: CliOptions) {
     }
 
     const provider = await getProvider(options);
-    const token = await resolveToken(options.account);
-    const auth = token
-      ? { accessToken: token.accessToken, isMicrosoft: token.isMicrosoft }
-      : undefined;
+    const auth = await attachmentAuthFor(options.account);
 
     try {
       info(`Downloading attachment ${options.attachmentId}...`);
@@ -3855,10 +4148,7 @@ async function cmdDownload(options: CliOptions) {
 
   const provider = await getProvider(options);
   const accountEmail = await provider.getCurrentEmail();
-  const token = await resolveToken(options.account);
-  const auth = token
-    ? { accessToken: token.accessToken, isMicrosoft: token.isMicrosoft }
-    : undefined;
+  const auth = await attachmentAuthFor(options.account);
 
   const attachments = await listAttachments(provider, options.threadId, accountEmail);
 
@@ -3913,6 +4203,33 @@ async function cmdExportEml(options: CliOptions) {
     error("Thread ID is required (or use --message <provider-message-id>)");
     console.log(`Usage: superhuman export eml <thread-id> [--message <id>] [--output <file.eml>] [--account <email>]`);
     process.exit(1);
+  }
+
+  // Outlook Web: inbox ids ARE message ids, and the raw MIME comes from the
+  // Outlook REST `$value` endpoint (not MS Graph). Route directly.
+  const owaProvider = await owaProviderFor(options.account);
+  if (owaProvider) {
+    const messageId = options.messageId || options.threadId;
+    if (!messageId) {
+      error("Message id or thread id required.");
+      process.exit(1);
+    }
+    try {
+      info(`Exporting message ${messageId} as .eml...`);
+      const owaTok = await owaProvider.getToken();
+      const raw = await downloadRawMessage(messageId, {
+        accessToken: owaTok.accessToken,
+        isMicrosoft: true,
+        isOutlookWeb: true,
+      });
+      const outputPath = options.outputPath || `${messageId}.eml`;
+      await Bun.write(outputPath, raw);
+      success(`Exported: ${outputPath} (${formatFileSize(raw.length)})`);
+    } catch (e) {
+      error(`Failed to export: ${(e as Error).message}`);
+      process.exit(1);
+    }
+    return;
   }
 
   const token = await requireToken(options);
@@ -4652,15 +4969,32 @@ async function cmdContacts(options: CliOptions) {
     process.exit(1);
   }
 
-  // Local-first: query Superhuman's own contacts table in the per-account
-  // SQLite blob. No CDP connection or provider API needed.
-  if (options.account) {
-    info(`Searching contacts in account: ${options.account}`);
+  // Outlook Web accounts have no local Superhuman contacts blob — query the
+  // Outlook REST contacts endpoint instead.
+  const owaProvider = await owaProviderFor(options.account);
+  let contacts: Contact[];
+  if (owaProvider) {
+    try {
+      contacts = await owaContacts(
+        owaProvider.fetcher(),
+        options.contactsQuery,
+        options.limit
+      );
+    } catch (e) {
+      error(`Contact search failed: ${(e as Error).message}`);
+      process.exit(1);
+    }
+  } else {
+    // Local-first: query Superhuman's own contacts table in the per-account
+    // SQLite blob. No CDP connection or provider API needed.
+    if (options.account) {
+      info(`Searching contacts in account: ${options.account}`);
+    }
+    contacts = searchContactsLocal(options.contactsQuery, {
+      limit: options.limit,
+      account: options.account || undefined,
+    });
   }
-  const contacts: Contact[] = searchContactsLocal(options.contactsQuery, {
-    limit: options.limit,
-    account: options.account || undefined,
-  });
 
   if (options.json) {
     printJson(contacts);
@@ -4676,6 +5010,7 @@ async function cmdContacts(options: CliOptions) {
 }
 
 async function cmdAi(options: CliOptions) {
+  if (await owaProviderFor(options.account)) owaUnsupported("AI search");
   if (!options.aiQuery) {
     error("Prompt is required");
     console.log(`Usage: superhuman ai "prompt"                    (ask AI / search emails)`);

--- a/src/connection-provider.ts
+++ b/src/connection-provider.ts
@@ -15,6 +15,8 @@ import {
 } from "./token-api";
 import { listAccounts } from "./accounts";
 import { SuperhumanProvider, type SuperhumanTokenInfo } from "./superhuman-provider";
+import { OutlookWebProvider } from "./outlook-web-provider";
+import { listOwaAccounts } from "./owa-token";
 
 /**
  * Account type detection result (matches send-api.ts AccountInfo)
@@ -139,6 +141,13 @@ export class CDPConnectionProvider implements ConnectionProvider {
  * otherwise fall back to CachedTokenProvider for backward compat.
  */
 function providerFromToken(token: TokenInfo, email: string): ConnectionProvider {
+  // Microsoft accounts route to the Outlook Web backend (the first-party OWA
+  // token), BEFORE the superhumanToken check — the stale MS entry in tokens.json
+  // still carries a dead superhumanToken that must not win. Google accounts are
+  // untouched and still use Superhuman.
+  if (token.isMicrosoft) {
+    return new OutlookWebProvider(token.email || email);
+  }
   if (token.superhumanToken) {
     const shTokenInfo: SuperhumanTokenInfo = {
       token: token.superhumanToken.token,
@@ -162,6 +171,16 @@ function providerFromToken(token: TokenInfo, email: string): ConnectionProvider 
  * @param options - Object with optional `account` and `port` fields
  * @returns ConnectionProvider or null if no tokens and no CDP
  */
+/** Case-insensitive check: does the OWA broker know this account? */
+async function isOwaAccount(email: string): Promise<boolean> {
+  try {
+    const accounts = await listOwaAccounts();
+    return accounts.some((a) => a.toLowerCase() === email.toLowerCase());
+  } catch {
+    return false;
+  }
+}
+
 export async function resolveProvider(
   options: { account?: string; port?: number }
 ): Promise<ConnectionProvider | null> {
@@ -176,6 +195,11 @@ export async function resolveProvider(
     const token = await getCachedToken(options.account);
     if (token) {
       return providerFromToken(token, options.account);
+    }
+    // Not in tokens.json — the account may be a Microsoft mailbox the OWA broker
+    // knows about (logged-in Outlook Web tab) but Superhuman never authed.
+    if (await isOwaAccount(options.account)) {
+      return new OutlookWebProvider(options.account);
     }
     return null;
   }
@@ -192,6 +216,13 @@ export async function resolveProvider(
     return new CachedTokenProvider(accounts[0]);
   }
 
-  // No cached accounts at all — caller must handle
+  // No cached accounts at all — fall back to any Microsoft mailbox the OWA
+  // broker knows about (no Superhuman auth needed for those).
+  const owa = await listOwaAccounts().catch(() => [] as string[]);
+  if (owa.length > 0) {
+    return new OutlookWebProvider(owa[0]!);
+  }
+
+  // Nothing available — caller must handle
   return null;
 }

--- a/src/inbox.ts
+++ b/src/inbox.ts
@@ -7,6 +7,8 @@
 
 import type { ConnectionProvider } from "./connection-provider";
 import { SuperhumanProvider } from "./superhuman-provider";
+import { OutlookWebProvider } from "./outlook-web-provider";
+import { owaListInbox, owaSearch } from "./outlook-rest-api";
 import { listInboxFromDB, buildFtsMatchExpr } from "./sqlite-search";
 
 export interface InboxThread {
@@ -601,6 +603,29 @@ export async function listInbox(
   provider: ConnectionProvider,
   options: ListInboxOptions = {}
 ): Promise<InboxThread[]> {
+  if (provider instanceof OutlookWebProvider) {
+    const me = await provider.getCurrentEmail();
+    let threads = await owaListInbox(provider.fetcher(), me, {
+      limit: options.limit,
+      needsReply: options.needsReply,
+      label: options.labels?.[0],
+    });
+    if (options.unreadOnly) {
+      threads = threads.filter((t) => t.labelIds.includes("UNREAD"));
+    }
+    if (options.exclude?.length) {
+      const patterns = options.exclude.map((p) => p.toLowerCase());
+      threads = threads.filter((t) => {
+        const fromEmail = t.from.email.toLowerCase();
+        const fromName = t.from.name.toLowerCase();
+        const subject = t.subject.toLowerCase();
+        return !patterns.some(
+          (p) => fromEmail.includes(p) || fromName.includes(p) || subject.includes(p)
+        );
+      });
+    }
+    return threads;
+  }
   if (provider instanceof SuperhumanProvider) {
     return listInboxSuperhuman(provider, options);
   }
@@ -619,6 +644,10 @@ export async function searchInbox(
   provider: ConnectionProvider,
   options: SearchOptions
 ): Promise<InboxThread[]> {
+  if (provider instanceof OutlookWebProvider) {
+    const me = await provider.getCurrentEmail();
+    return owaSearch(provider.fetcher(), me, options.query, { limit: options.limit });
+  }
   if (provider instanceof SuperhumanProvider) {
     return searchInboxSuperhuman(provider, options);
   }

--- a/src/labels.ts
+++ b/src/labels.ts
@@ -7,6 +7,18 @@
 
 import type { ConnectionProvider } from "./connection-provider";
 import { SuperhumanProvider } from "./superhuman-provider";
+import { OutlookWebProvider } from "./outlook-web-provider";
+import {
+  makeOwaFetcher,
+  owaListLabels,
+  owaListStarred,
+  owaArchive,
+  owaDelete,
+  owaMarkRead,
+  owaFlag,
+  owaAddLabel,
+  owaRemoveLabel,
+} from "./outlook-rest-api";
 import { listInboxFromDB, readThreadFromDB } from "./sqlite-search";
 import { refreshTokenViaCDP, type TokenInfo } from "./token-api";
 
@@ -51,6 +63,13 @@ export async function modifyThreadLabels(
 ): Promise<LabelResult> {
   if (addLabelIds.length === 0 && removeLabelIds.length === 0) {
     return { success: true };
+  }
+
+  // Outlook Web accounts: the access token is an Outlook REST token (not MS
+  // Graph), so route label writes to the Outlook REST backend. A "thread" id
+  // here is the message id (inbox listings expose message ids for OWA).
+  if (token.isOutlookWeb) {
+    return modifyThreadLabelsOwa(token.accessToken, threadId, addLabelIds, removeLabelIds);
   }
 
   const attempt = async (tok: TokenInfo): Promise<LabelResult> => {
@@ -234,6 +253,44 @@ function resolveMsMessageIds(email: string, threadId: string): string[] {
   return ids.length > 0 ? ids : [threadId];
 }
 
+/**
+ * Outlook Web: translate a superhuman label change into Outlook REST calls on
+ * the message. Read state → IsRead; STARRED → Flag; INBOX-removal → archive
+ * move; TRASH → deleted-items move; any other label → a Category add/remove.
+ * Never a hard delete. Applies to the single message id (OWA inbox ids are
+ * message ids).
+ */
+async function modifyThreadLabelsOwa(
+  accessToken: string,
+  messageId: string,
+  addLabelIds: string[],
+  removeLabelIds: string[]
+): Promise<LabelResult> {
+  if (!accessToken) {
+    return { success: false, error: "No Outlook Web access token available" };
+  }
+  const fetch = makeOwaFetcher(accessToken);
+  try {
+    if (removeLabelIds.includes("UNREAD")) await owaMarkRead(fetch, messageId, true);
+    else if (addLabelIds.includes("UNREAD")) await owaMarkRead(fetch, messageId, false);
+
+    if (removeLabelIds.includes("STARRED")) await owaFlag(fetch, messageId, false);
+    else if (addLabelIds.includes("STARRED")) await owaFlag(fetch, messageId, true);
+
+    if (addLabelIds.includes("TRASH")) await owaDelete(fetch, [messageId]);
+    else if (removeLabelIds.includes("INBOX")) await owaArchive(fetch, [messageId]);
+
+    // Any remaining (non-system) labels map to Outlook Categories.
+    const system = new Set(["UNREAD", "STARRED", "TRASH", "INBOX", "SH_IMPORTANT", "SH_OTHER"]);
+    for (const l of addLabelIds) if (!system.has(l)) await owaAddLabel(fetch, messageId, l);
+    for (const l of removeLabelIds) if (!system.has(l)) await owaRemoveLabel(fetch, messageId, l);
+
+    return { success: true };
+  } catch (e: any) {
+    return { success: false, error: e.message };
+  }
+}
+
 /** Map label add/remove sets to an MS Graph message PATCH body. */
 export function computeMicrosoftMessageUpdates(
   addLabelIds: string[],
@@ -300,6 +357,9 @@ export interface LabelResult {
  * @returns Array of labels with id and name
  */
 export async function listLabels(provider: ConnectionProvider): Promise<Label[]> {
+  if (provider instanceof OutlookWebProvider) {
+    return owaListLabels(provider.fetcher());
+  }
   if (provider instanceof SuperhumanProvider) {
     if (!provider.hasPortal()) {
       throw new Error(
@@ -412,6 +472,11 @@ export async function listStarred(
   provider: ConnectionProvider,
   limit: number = 50
 ): Promise<StarredThread[]> {
+  if (provider instanceof OutlookWebProvider) {
+    const me = await provider.getCurrentEmail();
+    return owaListStarred(provider.fetcher(), me, { limit });
+  }
+
   if (!(provider instanceof SuperhumanProvider)) {
     throw new Error(
       "SuperhumanProvider required. Run 'superhuman account auth' to authenticate."

--- a/src/outlook-rest-api.ts
+++ b/src/outlook-rest-api.ts
@@ -281,13 +281,19 @@ export async function owaGetThread(
     return one ? [messageToThreadMessage(one)] : [];
   }
 
+  // NOTE: Exchange rejects $filter=ConversationId combined with $orderby
+  // ("InefficientFilter", 400) — same constraint the MS Graph path documents.
+  // Fetch unsorted, then sort oldest-first client-side.
   const path = `/messages?$filter=${encodeURIComponent(
     `ConversationId eq '${cid}'`
-  )}&$orderby=${encodeURIComponent("ReceivedDateTime asc")}&$select=${encodeURIComponent(
-    select
-  )}&$top=100`;
+  )}&$select=${encodeURIComponent(select)}&$top=100`;
   const data = await fetch("GET", path);
-  return (data?.value || []).map((m: any) => messageToThreadMessage(m));
+  const msgs = (data?.value || []).map((m: any) => messageToThreadMessage(m));
+  msgs.sort(
+    (a: ThreadMessage, b: ThreadMessage) =>
+      new Date(a.date || 0).getTime() - new Date(b.date || 0).getTime()
+  );
+  return msgs;
 }
 
 // ---------------------------------------------------------------------------
@@ -447,13 +453,13 @@ export async function owaListStarred(
   opts: { limit?: number } = {}
 ): Promise<StarredThread[]> {
   const top = opts.limit ?? 50;
+  // Exchange rejects $filter combined with $orderby (InefficientFilter); sort
+  // newest-first client-side instead.
   const path = `/messages?$top=${top}&$select=${encodeURIComponent(
     MSG_SELECT
-  )}&$filter=${encodeURIComponent("Flag/FlagStatus eq 'Flagged'")}&$orderby=${encodeURIComponent(
-    "ReceivedDateTime desc"
-  )}`;
+  )}&$filter=${encodeURIComponent("Flag/FlagStatus eq 'Flagged'")}`;
   const data = await fetch("GET", path);
-  return (data?.value || []).map((m: any): StarredThread => {
+  const rows = (data?.value || []).map((m: any): StarredThread => {
     const t = messageToInboxThread(m, meEmail);
     return {
       id: t.id,
@@ -464,6 +470,11 @@ export async function owaListStarred(
       labelIds: t.labelIds,
     };
   });
+  rows.sort(
+    (a: StarredThread, b: StarredThread) =>
+      new Date(b.date || 0).getTime() - new Date(a.date || 0).getTime()
+  );
+  return rows;
 }
 
 /**

--- a/src/outlook-rest-api.ts
+++ b/src/outlook-rest-api.ts
@@ -1,0 +1,745 @@
+/**
+ * Outlook Web (OWA) REST API client + per-verb data functions.
+ *
+ * Talks to the Outlook REST API v2.0 (base https://outlook.office.com/api/v2.0/me)
+ * using the first-party OWA session token brokered by owa-token.ts (aud =
+ * https://outlook.office.com, Mail.ReadWrite / Mail.Send scopes). This is the
+ * no-consent path for Microsoft accounts on tenants (e.g. UVA) that gate
+ * third-party mail apps behind admin consent.
+ *
+ * Each data function returns the SAME JSON shape the Superhuman path returns
+ * (InboxThread, ThreadMessage, StarredThread, Label, CalendarEvent, Attachment,
+ * Contact, Draft) so the CLI's output contracts — parsed by the email-handling
+ * skill — are identical regardless of backend.
+ *
+ * The low-level `owaFetch(token, method, path, body?)` is the only thing that
+ * touches the network. Data functions receive an `OwaFetcher` (a bound
+ * `owaFetch`) so unit tests can inject a mock returning raw OWA REST fixtures
+ * and assert both the emitted shape AND the REST path/method/body.
+ */
+
+import type { InboxThread } from "./inbox";
+import type { ThreadMessage } from "./read";
+import type { Label, StarredThread } from "./labels";
+import type { CalendarEvent } from "./calendar";
+import type { Attachment } from "./attachments";
+import type { Contact } from "./contacts";
+import type { Draft } from "./services/draft-service";
+
+/** Outlook REST v2.0 base for the signed-in user. */
+export const OWA_REST_BASE = "https://outlook.office.com/api/v2.0/me";
+
+/**
+ * A bound `owaFetch` — the seam data functions call. The provider supplies one
+ * that fetches a fresh token first; tests supply a mock returning fixtures.
+ */
+export type OwaFetcher = (
+  method: string,
+  path: string,
+  body?: any
+) => Promise<any>;
+
+/**
+ * Low-level Outlook REST call. Bearer auth, JSON in/out. Returns parsed JSON,
+ * or null for 204 (no content). Throws on !ok with status + body. Never logs
+ * the token.
+ */
+export async function owaFetch(
+  token: string,
+  method: string,
+  path: string,
+  body?: any
+): Promise<any> {
+  const url = path.startsWith("http") ? path : `${OWA_REST_BASE}${path}`;
+  const resp = await fetch(url, {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+
+  if (resp.status === 204) return null;
+
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => "");
+    throw new Error(
+      `Outlook REST error: ${resp.status} ${resp.statusText} — ${method} ${path} ${text.slice(0, 500)}`
+    );
+  }
+
+  const text = await resp.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+/**
+ * Fetch raw (non-JSON) bytes from an Outlook REST path — used for `$value`
+ * (RFC822 MIME) exports. Bearer auth; throws on !ok.
+ */
+export async function owaFetchRaw(token: string, path: string): Promise<Uint8Array> {
+  const url = path.startsWith("http") ? path : `${OWA_REST_BASE}${path}`;
+  const resp = await fetch(url, {
+    method: "GET",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => "");
+    throw new Error(
+      `Outlook REST error: ${resp.status} ${resp.statusText} — GET ${path} ${text.slice(0, 300)}`
+    );
+  }
+  return new Uint8Array(await resp.arrayBuffer());
+}
+
+/** Build a bound fetcher for a concrete access token. */
+export function makeOwaFetcher(token: string): OwaFetcher {
+  return (method, path, body) => owaFetch(token, method, path, body);
+}
+
+// ---------------------------------------------------------------------------
+// Shape helpers — map Outlook REST (PascalCase) → superhuman JSON contracts
+// ---------------------------------------------------------------------------
+
+/** Fields selected for a message list row (no body). */
+const MSG_SELECT =
+  "Id,Subject,From,ToRecipients,CcRecipients,ReceivedDateTime,BodyPreview,ConversationId,IsRead,Flag,Categories,InternetMessageId";
+
+/** Map an Outlook Recipient / EmailAddress to {email,name}. */
+function addr(r: any): { email: string; name: string } {
+  const e = r?.EmailAddress ?? r ?? {};
+  return { email: e.Address || "", name: e.Name || "" };
+}
+
+/** Map an Outlook recipient list to [{email,name}], dropping entries with no email. */
+function addrs(list: any): { email: string; name: string }[] {
+  if (!Array.isArray(list)) return [];
+  return list.map(addr).filter((r) => r.email);
+}
+
+/**
+ * Derive superhuman-style labelIds from an Outlook message: UNREAD when
+ * !IsRead, STARRED when flagged, plus any Categories verbatim.
+ */
+function labelIdsOf(m: any): string[] {
+  const ids: string[] = [];
+  if (m?.IsRead === false) ids.push("UNREAD");
+  if (m?.Flag?.FlagStatus === "Flagged") ids.push("STARRED");
+  if (Array.isArray(m?.Categories)) ids.push(...m.Categories);
+  return ids;
+}
+
+/** Extract a filename extension (lowercased, no dot). */
+function extOf(name: string): string {
+  const parts = (name || "").split(".");
+  return parts.length > 1 ? parts[parts.length - 1]!.toLowerCase() : "";
+}
+
+/** Convert a plain message object into an InboxThread (+ optional body). */
+function messageToInboxThread(
+  m: any,
+  meEmail: string
+): InboxThread & { body?: string } {
+  const from = addr(m.From);
+  const isFromMe =
+    from.email !== "" && from.email.toLowerCase() === meEmail.toLowerCase();
+  const thread: InboxThread & { body?: string } = {
+    id: m.Id || "",
+    subject: m.Subject || "",
+    from,
+    to: addrs(m.ToRecipients),
+    cc: addrs(m.CcRecipients),
+    date: m.ReceivedDateTime || "",
+    snippet: m.BodyPreview || "",
+    labelIds: labelIdsOf(m),
+    messageCount: 1,
+    isFromMe,
+    awaitingReply: !isFromMe,
+  };
+  if (m.Body?.Content !== undefined) thread.body = m.Body.Content;
+  return thread;
+}
+
+/** Convert a message object into a ThreadMessage (body included when present). */
+function messageToThreadMessage(m: any): ThreadMessage {
+  return {
+    id: m.Id || "",
+    threadId: m.ConversationId || "",
+    subject: m.Subject || "",
+    from: addr(m.From),
+    to: addrs(m.ToRecipients),
+    cc: addrs(m.CcRecipients),
+    date: m.ReceivedDateTime || "",
+    snippet: m.BodyPreview || "",
+    body: m.Body?.Content || undefined,
+  };
+}
+
+/** Build an Outlook recipient object list from "Name <email>" / bare-email strings. */
+function toRecipientList(items?: string[]): any[] {
+  if (!items || items.length === 0) return [];
+  return items.map((s) => {
+    const m = s.match(/^(.*?)\s*<([^<>]+)>\s*$/);
+    if (m) return { EmailAddress: { Name: m[1]!.trim() || undefined, Address: m[2]!.trim() } };
+    return { EmailAddress: { Address: s.trim() } };
+  });
+}
+
+/** Body block for create/patch: HTML unless the caller asked for text. */
+function bodyBlock(content: string, html: boolean): any {
+  return { ContentType: html ? "HTML" : "Text", Content: content };
+}
+
+// ---------------------------------------------------------------------------
+// Read verbs
+// ---------------------------------------------------------------------------
+
+export interface OwaListInboxOptions {
+  limit?: number;
+  needsReply?: boolean;
+  /** Keep only threads carrying this label (Category name / UNREAD / STARRED). */
+  label?: string;
+  withBody?: boolean;
+}
+
+/** List the inbox (latest messages first). */
+export async function owaListInbox(
+  fetch: OwaFetcher,
+  meEmail: string,
+  opts: OwaListInboxOptions = {}
+): Promise<(InboxThread & { body?: string })[]> {
+  const top = opts.limit ?? 10;
+  const select = opts.withBody ? `${MSG_SELECT},Body` : MSG_SELECT;
+  const path = `/mailfolders/inbox/messages?$top=${top}&$select=${encodeURIComponent(
+    select
+  )}&$orderby=${encodeURIComponent("ReceivedDateTime desc")}`;
+  const data = await fetch("GET", path);
+  let threads: (InboxThread & { body?: string })[] = (data?.value || []).map(
+    (m: any) => messageToInboxThread(m, meEmail)
+  );
+
+  if (opts.needsReply) threads = threads.filter((t) => !t.isFromMe);
+  if (opts.label) {
+    const want = opts.label.toLowerCase();
+    threads = threads.filter((t) =>
+      t.labelIds.some((l) => l.toLowerCase() === want)
+    );
+  }
+  return threads.slice(0, top);
+}
+
+export interface OwaSearchOptions {
+  limit?: number;
+  withBody?: boolean;
+}
+
+/** Full-text search across the mailbox via $search. */
+export async function owaSearch(
+  fetch: OwaFetcher,
+  meEmail: string,
+  query: string,
+  opts: OwaSearchOptions = {}
+): Promise<(InboxThread & { body?: string })[]> {
+  const top = opts.limit ?? 25;
+  const select = opts.withBody ? `${MSG_SELECT},Body` : MSG_SELECT;
+  // $search cannot combine with $orderby on Outlook REST; results come ranked.
+  const path = `/messages?$top=${top}&$select=${encodeURIComponent(
+    select
+  )}&$search=${encodeURIComponent(`"${query}"`)}`;
+  const data = await fetch("GET", path);
+  return (data?.value || []).map((m: any) => messageToInboxThread(m, meEmail));
+}
+
+/**
+ * Read every message in a thread. Resolves the message's ConversationId, then
+ * lists the whole conversation oldest-first with bodies.
+ */
+export async function owaGetThread(
+  fetch: OwaFetcher,
+  id: string
+): Promise<ThreadMessage[]> {
+  // Resolve the conversation id from the passed message id.
+  const head = await fetch(
+    "GET",
+    `/messages/${encodeURIComponent(id)}?$select=ConversationId`
+  );
+  const cid: string = head?.ConversationId;
+  const select = `${MSG_SELECT},Body`;
+
+  if (!cid) {
+    // Fall back to the single message when it has no conversation id.
+    const one = await fetch(
+      "GET",
+      `/messages/${encodeURIComponent(id)}?$select=${encodeURIComponent(select)}`
+    );
+    return one ? [messageToThreadMessage(one)] : [];
+  }
+
+  const path = `/messages?$filter=${encodeURIComponent(
+    `ConversationId eq '${cid}'`
+  )}&$orderby=${encodeURIComponent("ReceivedDateTime asc")}&$select=${encodeURIComponent(
+    select
+  )}&$top=100`;
+  const data = await fetch("GET", path);
+  return (data?.value || []).map((m: any) => messageToThreadMessage(m));
+}
+
+// ---------------------------------------------------------------------------
+// Compose verbs (create draft / reply / forward / send)
+// ---------------------------------------------------------------------------
+
+export interface OwaCreateDraftInput {
+  to?: string[];
+  cc?: string[];
+  bcc?: string[];
+  subject?: string;
+  body?: string;
+  /** true → HTML body (default), false → plain text. */
+  html?: boolean;
+}
+
+export interface OwaDraftResult {
+  id: string;
+  threadId?: string;
+}
+
+/** Create a draft in the Drafts folder (POST /messages). Returns its Id. */
+export async function owaCreateDraft(
+  fetch: OwaFetcher,
+  input: OwaCreateDraftInput
+): Promise<OwaDraftResult> {
+  const msg: any = {
+    Subject: input.subject || "",
+    Body: bodyBlock(input.body || "", input.html !== false),
+    ToRecipients: toRecipientList(input.to),
+  };
+  if (input.cc?.length) msg.CcRecipients = toRecipientList(input.cc);
+  if (input.bcc?.length) msg.BccRecipients = toRecipientList(input.bcc);
+  const created = await fetch("POST", "/messages", msg);
+  return { id: created?.Id || "", threadId: created?.ConversationId };
+}
+
+/**
+ * Create a reply draft for message `id` (createReply / createReplyAll), then
+ * prepend the user's text above Outlook's quoted original. Returns the draft Id.
+ */
+export async function owaReply(
+  fetch: OwaFetcher,
+  id: string,
+  opts: { body?: string; html?: boolean; all?: boolean }
+): Promise<OwaDraftResult> {
+  const action = opts.all ? "createReplyAll" : "createReply";
+  const draft = await fetch("POST", `/messages/${encodeURIComponent(id)}/${action}`);
+  const draftId: string = draft?.Id || "";
+  if (opts.body && draftId) {
+    const existing: string = draft?.Body?.Content || "";
+    const html = opts.html !== false;
+    const merged = html
+      ? `${opts.body}<br><br>${existing}`
+      : `${opts.body}\n\n${existing}`;
+    await fetch("PATCH", `/messages/${encodeURIComponent(draftId)}`, {
+      Body: bodyBlock(merged, html),
+    });
+  }
+  return { id: draftId, threadId: draft?.ConversationId };
+}
+
+/**
+ * Create a forward draft for message `id` (createForward), set recipients and
+ * prepend the user's note. Returns the draft Id.
+ */
+export async function owaForward(
+  fetch: OwaFetcher,
+  id: string,
+  opts: { to?: string[]; body?: string; html?: boolean }
+): Promise<OwaDraftResult> {
+  const draft = await fetch("POST", `/messages/${encodeURIComponent(id)}/createForward`);
+  const draftId: string = draft?.Id || "";
+  if (draftId) {
+    const patch: any = {};
+    if (opts.to?.length) patch.ToRecipients = toRecipientList(opts.to);
+    if (opts.body) {
+      const existing: string = draft?.Body?.Content || "";
+      const html = opts.html !== false;
+      patch.Body = bodyBlock(
+        html ? `${opts.body}<br><br>${existing}` : `${opts.body}\n\n${existing}`,
+        html
+      );
+    }
+    if (Object.keys(patch).length > 0) {
+      await fetch("PATCH", `/messages/${encodeURIComponent(draftId)}`, patch);
+    }
+  }
+  return { id: draftId, threadId: draft?.ConversationId };
+}
+
+/** Send an existing draft (POST /messages/{id}/send → 204). */
+export async function owaSendDraft(fetch: OwaFetcher, draftId: string): Promise<void> {
+  await fetch("POST", `/messages/${encodeURIComponent(draftId)}/send`);
+}
+
+/** Compose + send in one call (POST /sendmail, SaveToSentItems). */
+export async function owaSendNew(
+  fetch: OwaFetcher,
+  input: OwaCreateDraftInput
+): Promise<void> {
+  const message: any = {
+    Subject: input.subject || "",
+    Body: bodyBlock(input.body || "", input.html !== false),
+    ToRecipients: toRecipientList(input.to),
+  };
+  if (input.cc?.length) message.CcRecipients = toRecipientList(input.cc);
+  if (input.bcc?.length) message.BccRecipients = toRecipientList(input.bcc);
+  await fetch("POST", "/sendmail", { Message: message, SaveToSentItems: true });
+}
+
+// ---------------------------------------------------------------------------
+// Mutation verbs (archive / delete / read / flag / label)
+// ---------------------------------------------------------------------------
+
+/** Move a message to a well-known destination folder. */
+async function owaMove(fetch: OwaFetcher, id: string, dest: string): Promise<void> {
+  await fetch("POST", `/messages/${encodeURIComponent(id)}/move`, {
+    DestinationId: dest,
+  });
+}
+
+/** Archive messages (move to the Archive folder). Never a hard delete. */
+export async function owaArchive(fetch: OwaFetcher, ids: string[]): Promise<void> {
+  for (const id of ids) await owaMove(fetch, id, "archive");
+}
+
+/** Delete messages by moving them to Deleted Items (NOT a hard delete). */
+export async function owaDelete(fetch: OwaFetcher, ids: string[]): Promise<void> {
+  for (const id of ids) await owaMove(fetch, id, "deleteditems");
+}
+
+/** Mark a message read/unread (PATCH IsRead). */
+export async function owaMarkRead(
+  fetch: OwaFetcher,
+  id: string,
+  read: boolean
+): Promise<void> {
+  await fetch("PATCH", `/messages/${encodeURIComponent(id)}`, { IsRead: read });
+}
+
+/** Flag/unflag a message (star ≈ flag). */
+export async function owaFlag(
+  fetch: OwaFetcher,
+  id: string,
+  on: boolean
+): Promise<void> {
+  await fetch("PATCH", `/messages/${encodeURIComponent(id)}`, {
+    Flag: { FlagStatus: on ? "Flagged" : "NotFlagged" },
+  });
+}
+
+/** List flagged (starred) messages. */
+export async function owaListStarred(
+  fetch: OwaFetcher,
+  meEmail: string,
+  opts: { limit?: number } = {}
+): Promise<StarredThread[]> {
+  const top = opts.limit ?? 50;
+  const path = `/messages?$top=${top}&$select=${encodeURIComponent(
+    MSG_SELECT
+  )}&$filter=${encodeURIComponent("Flag/FlagStatus eq 'Flagged'")}&$orderby=${encodeURIComponent(
+    "ReceivedDateTime desc"
+  )}`;
+  const data = await fetch("GET", path);
+  return (data?.value || []).map((m: any): StarredThread => {
+    const t = messageToInboxThread(m, meEmail);
+    return {
+      id: t.id,
+      subject: t.subject,
+      from: t.from,
+      date: t.date,
+      snippet: t.snippet,
+      labelIds: t.labelIds,
+    };
+  });
+}
+
+/**
+ * List labels. Outlook has no Gmail-style labels; the closest analogues are
+ * mail folders (Categories are per-message tags). `/me/outlook/masterCategories`
+ * 404s on Outlook REST v2.0, so we surface the folder set as labels.
+ */
+export async function owaListLabels(fetch: OwaFetcher): Promise<Label[]> {
+  const data = await fetch(
+    "GET",
+    "/mailfolders?$top=100&$select=Id,DisplayName"
+  );
+  return (data?.value || []).map((f: any): Label => ({
+    id: f.Id || "",
+    name: f.DisplayName || f.Id || "",
+    type: "folder",
+  }));
+}
+
+/** Read a message's current Categories. */
+async function owaGetCategories(fetch: OwaFetcher, id: string): Promise<string[]> {
+  const m = await fetch(
+    "GET",
+    `/messages/${encodeURIComponent(id)}?$select=Categories`
+  );
+  return Array.isArray(m?.Categories) ? m.Categories : [];
+}
+
+/** Add a Category to a message (labels ≈ categories on Outlook). */
+export async function owaAddLabel(
+  fetch: OwaFetcher,
+  id: string,
+  name: string
+): Promise<void> {
+  const cats = await owaGetCategories(fetch, id);
+  if (cats.includes(name)) return;
+  await fetch("PATCH", `/messages/${encodeURIComponent(id)}`, {
+    Categories: [...cats, name],
+  });
+}
+
+/** Remove a Category from a message. */
+export async function owaRemoveLabel(
+  fetch: OwaFetcher,
+  id: string,
+  name: string
+): Promise<void> {
+  const cats = await owaGetCategories(fetch, id);
+  if (!cats.includes(name)) return;
+  await fetch("PATCH", `/messages/${encodeURIComponent(id)}`, {
+    Categories: cats.filter((c) => c !== name),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Drafts listing (for `draft list`)
+// ---------------------------------------------------------------------------
+
+/** List draft messages, mapped to the unified Draft shape. */
+export async function owaListDrafts(
+  fetch: OwaFetcher,
+  limit = 50
+): Promise<Draft[]> {
+  const select = `${MSG_SELECT},Body`;
+  const path = `/mailfolders/drafts/messages?$top=${limit}&$select=${encodeURIComponent(
+    select
+  )}&$orderby=${encodeURIComponent("LastModifiedDateTime desc")}`;
+  const data = await fetch("GET", path);
+  return (data?.value || []).map((m: any): Draft => {
+    const from = addr(m.From);
+    return {
+      id: m.Id || "",
+      subject: m.Subject || "",
+      from: from.name ? `${from.name} <${from.email}>` : from.email,
+      to: addrs(m.ToRecipients).map((r) => r.email),
+      cc: addrs(m.CcRecipients).map((r) => r.email),
+      bcc: [],
+      preview: m.BodyPreview || "",
+      timestamp: m.ReceivedDateTime || "",
+      source: "native",
+      threadId: m.ConversationId,
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Calendar verbs
+// ---------------------------------------------------------------------------
+
+/** Normalize an Outlook REST calendar event into the CalendarEvent contract. */
+function eventToCalendarEvent(e: any): CalendarEvent {
+  return {
+    id: e.Id || "",
+    summary: e.Subject || "",
+    description: e.Body?.Content || e.BodyPreview || "",
+    start: e.Start?.DateTime || "",
+    end: e.End?.DateTime || "",
+    location: e.Location?.DisplayName || "",
+    attendees: (e.Attendees || [])
+      .map((a: any) => a.EmailAddress?.Address || a.EmailAddress?.Name || "")
+      .filter(Boolean),
+    organizer:
+      e.Organizer?.EmailAddress?.Address || e.Organizer?.EmailAddress?.Name || "",
+    isAllDay: !!e.IsAllDay,
+    status: e.ShowAs || "",
+    calendarId: e.calendarId || "",
+  };
+}
+
+export interface OwaListEventsOptions {
+  timeMin?: string;
+  timeMax?: string;
+  limit?: number;
+}
+
+/** List calendar events in a window (calendarview). */
+export async function owaListEvents(
+  fetch: OwaFetcher,
+  opts: OwaListEventsOptions = {}
+): Promise<CalendarEvent[]> {
+  const start = opts.timeMin || new Date().toISOString();
+  const end = opts.timeMax || new Date(Date.now() + 7 * 86400000).toISOString();
+  const top = opts.limit ?? 50;
+  const path =
+    `/calendarview?startDateTime=${encodeURIComponent(start)}` +
+    `&endDateTime=${encodeURIComponent(end)}&$top=${top}` +
+    `&$orderby=${encodeURIComponent("Start/DateTime")}`;
+  const data = await fetch("GET", path);
+  return (data?.value || []).map(eventToCalendarEvent);
+}
+
+export interface OwaEventInput {
+  summary?: string;
+  start?: string;
+  end?: string;
+  description?: string;
+  location?: string;
+  attendees?: string[];
+  timeZone?: string;
+}
+
+/** Build the Outlook event body for create/update. */
+function eventBody(input: OwaEventInput): any {
+  const tz = input.timeZone || "America/New_York";
+  const data: any = {};
+  if (input.summary !== undefined) data.Subject = input.summary;
+  if (input.start !== undefined) data.Start = { DateTime: input.start, TimeZone: tz };
+  if (input.end !== undefined) data.End = { DateTime: input.end, TimeZone: tz };
+  if (input.description !== undefined)
+    data.Body = { ContentType: "Text", Content: input.description };
+  if (input.location !== undefined) data.Location = { DisplayName: input.location };
+  if (input.attendees?.length) {
+    data.Attendees = input.attendees.map((e) => ({
+      EmailAddress: { Address: e },
+      Type: "Required",
+    }));
+  }
+  return data;
+}
+
+/** Create a calendar event (POST /events). Returns the new event id. */
+export async function owaCreateEvent(
+  fetch: OwaFetcher,
+  input: OwaEventInput
+): Promise<string> {
+  const created = await fetch("POST", "/events", eventBody(input));
+  return created?.Id || "";
+}
+
+/** Update a calendar event (PATCH /events/{id}). */
+export async function owaUpdateEvent(
+  fetch: OwaFetcher,
+  eventId: string,
+  input: OwaEventInput
+): Promise<void> {
+  await fetch("PATCH", `/events/${encodeURIComponent(eventId)}`, eventBody(input));
+}
+
+/** Delete a calendar event (DELETE /events/{id}). */
+export async function owaDeleteEvent(
+  fetch: OwaFetcher,
+  eventId: string
+): Promise<void> {
+  await fetch("DELETE", `/events/${encodeURIComponent(eventId)}`);
+}
+
+/**
+ * Free/busy over a window. Outlook REST v2.0 lacks a clean getSchedule for the
+ * OWA first-party token, so we derive busy slots from the user's own events in
+ * the range (their calendarview) — sufficient for the CLI's availability use.
+ */
+export async function owaFreeBusy(
+  fetch: OwaFetcher,
+  timeMin: string,
+  timeMax: string
+): Promise<{ busy: { start: string; end: string }[]; free: { start: string; end: string }[] }> {
+  const events = await owaListEvents(fetch, { timeMin, timeMax, limit: 200 });
+  const busy = events
+    .filter((e) => e.status !== "Free" && !e.isAllDay)
+    .map((e) => ({ start: e.start, end: e.end }))
+    .filter((s) => s.start && s.end);
+  return { busy, free: [] };
+}
+
+// ---------------------------------------------------------------------------
+// Attachments
+// ---------------------------------------------------------------------------
+
+/** List non-inline attachments on a message. */
+export async function owaListAttachments(
+  fetch: OwaFetcher,
+  msgId: string
+): Promise<Attachment[]> {
+  const path = `/messages/${encodeURIComponent(
+    msgId
+  )}/attachments?$select=Id,Name,ContentType,Size,IsInline`;
+  const data = await fetch("GET", path);
+  return (data?.value || [])
+    .filter((a: any) => !a.IsInline)
+    .map((a: any): Attachment => ({
+      id: a.Id || "",
+      attachmentId: a.Id || "",
+      name: a.Name || "attachment",
+      mimeType: a.ContentType || "application/octet-stream",
+      extension: extOf(a.Name || ""),
+      messageId: msgId,
+      threadId: msgId,
+      inline: false,
+    }));
+}
+
+/** Download an attachment's bytes (base64). */
+export async function owaDownloadAttachment(
+  fetch: OwaFetcher,
+  msgId: string,
+  attachmentId: string
+): Promise<{ data: string; size: number }> {
+  const att = await fetch(
+    "GET",
+    `/messages/${encodeURIComponent(msgId)}/attachments/${encodeURIComponent(attachmentId)}`
+  );
+  const base64: string = att?.ContentBytes || "";
+  return { data: base64, size: att?.Size || Math.ceil((base64.length * 3) / 4) };
+}
+
+// ---------------------------------------------------------------------------
+// Contacts
+// ---------------------------------------------------------------------------
+
+/**
+ * Search the user's Outlook contacts. Outlook REST v2.0 has no reliable
+ * `$search` on /contacts, so we page the contact set and substring-match
+ * client-side on name/email, returning the Contact shape.
+ */
+export async function owaContacts(
+  fetch: OwaFetcher,
+  query: string,
+  limit = 20
+): Promise<Contact[]> {
+  const data = await fetch(
+    "GET",
+    "/contacts?$top=200&$select=DisplayName,EmailAddresses"
+  );
+  const q = query.toLowerCase();
+  const out: Contact[] = [];
+  for (const c of data?.value || []) {
+    const name: string = c.DisplayName || "";
+    const emails: any[] = Array.isArray(c.EmailAddresses) ? c.EmailAddresses : [];
+    for (const e of emails) {
+      const email: string = e.Address || "";
+      if (!email) continue;
+      if (q && !name.toLowerCase().includes(q) && !email.toLowerCase().includes(q)) {
+        continue;
+      }
+      out.push({ email, name: name || undefined });
+    }
+  }
+  return out.slice(0, limit);
+}

--- a/src/outlook-web-provider.ts
+++ b/src/outlook-web-provider.ts
@@ -1,0 +1,73 @@
+/**
+ * Outlook Web (OWA) Provider
+ *
+ * A ConnectionProvider for Microsoft (Exchange Online) accounts driven through
+ * the live Outlook Web session's own first-party token — no Superhuman, no new
+ * OAuth grant. Sibling to SuperhumanProvider.
+ *
+ * It carries the account email and exposes a single data primitive,
+ * `owaFetch(method, path, body?)`, which fetches a fresh OWA token from the
+ * broker (owa-token.ts) and calls the Outlook REST client (outlook-rest-api.ts).
+ * CDP is used only by the token broker; verbs speak plain HTTPS + Bearer.
+ */
+
+import type { ConnectionProvider, AccountInfo } from "./connection-provider";
+import type { TokenInfo } from "./token-api";
+import { getOwaToken } from "./owa-token";
+import { owaFetch, owaFetchRaw, type OwaFetcher } from "./outlook-rest-api";
+
+export class OutlookWebProvider implements ConnectionProvider {
+  constructor(private email: string) {}
+
+  /**
+   * TokenInfo-compatible shim so callers that read `token.accessToken`,
+   * `token.email`, `token.isMicrosoft` keep working. `isOutlookWeb` marks the
+   * access token as an Outlook REST token so verbs route to the OWA backend.
+   */
+  async getToken(email?: string): Promise<TokenInfo> {
+    const tok = await getOwaToken(email || this.email);
+    // Adopt the broker's canonical email (decoded from the token) so downstream
+    // `me`-detection matches the real mailbox address.
+    this.email = tok.email || this.email;
+    return {
+      accessToken: tok.accessToken,
+      email: tok.email,
+      expires: tok.expiresOn,
+      isMicrosoft: true,
+      isOutlookWeb: true,
+    };
+  }
+
+  async getCurrentEmail(): Promise<string> {
+    return this.email;
+  }
+
+  async getAccountInfo(): Promise<AccountInfo> {
+    return { email: this.email, isMicrosoft: true, provider: "microsoft" };
+  }
+
+  async disconnect(): Promise<void> {
+    // No persistent connection — the broker manages CDP lifetimes itself.
+  }
+
+  /**
+   * Fetch a fresh OWA token then call the Outlook REST client. This is the seam
+   * verbs and tests use (tests monkeypatch this method to return fixtures).
+   */
+  async owaFetch(method: string, path: string, body?: any): Promise<any> {
+    const tok = await getOwaToken(this.email);
+    this.email = tok.email || this.email;
+    return owaFetch(tok.accessToken, method, path, body);
+  }
+
+  /** Raw (non-JSON) fetch for `$value` MIME exports. */
+  async owaFetchRaw(path: string): Promise<Uint8Array> {
+    const tok = await getOwaToken(this.email);
+    return owaFetchRaw(tok.accessToken, path);
+  }
+
+  /** A bound OwaFetcher for the data functions in outlook-rest-api.ts. */
+  fetcher(): OwaFetcher {
+    return (method, path, body) => this.owaFetch(method, path, body);
+  }
+}

--- a/src/owa-token.ts
+++ b/src/owa-token.ts
@@ -1,0 +1,223 @@
+/**
+ * Outlook Web (OWA) token broker.
+ *
+ * Piggybacks the already-authenticated Outlook Web session running in the CDP
+ * browser (port 9222): reads the session's own first-party access token
+ * ("One Outlook Web" app, aud=https://outlook.office.com, full Mail.* scopes)
+ * from the page's MSAL localStorage cache. No new OAuth grant is required — this
+ * is the only no-consent path on tenants (e.g. UVA) that gate third-party apps
+ * behind admin consent.
+ *
+ * The token carries Mail.ReadWrite / Mail.Send and lasts ~24h; MSAL in the OWA
+ * page silently re-mints it while the browser stays signed in. When our cached
+ * copy is stale we reload the OWA tab to force a fresh mint, then re-read.
+ */
+
+import CDP from "chrome-remote-interface";
+import { promises as fs } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+import { getCDPHost, cdpPortCandidates, hostMatches } from "./cdp-endpoint";
+
+/** Hosts that indicate a logged-in Outlook Web tab. */
+const OWA_HOSTS = ["outlook.cloud.microsoft", "outlook.office.com", "outlook.office365.com"];
+
+/** Refresh when this close to (or past) expiry. */
+const EXPIRY_BUFFER_MS = 5 * 60 * 1000;
+
+/** How long to wait after a tab reload for OWA to bootstrap + re-mint the token. */
+const RELOAD_SETTLE_MS = 4500;
+
+export interface OwaToken {
+  accessToken: string;
+  /** Account UPN / email, decoded from the token's `upn` claim. */
+  email: string;
+  /** Expiry as ms epoch. */
+  expiresOn: number;
+}
+
+const memCache = new Map<string, OwaToken>();
+
+function cacheFile(): string {
+  return join(homedir(), ".config", "superhuman-cli", "owa-tokens.json");
+}
+
+async function loadDiskCache(): Promise<Record<string, OwaToken>> {
+  try {
+    return JSON.parse(await fs.readFile(cacheFile(), "utf8"));
+  } catch {
+    return {};
+  }
+}
+
+async function saveDiskCache(map: Record<string, OwaToken>): Promise<void> {
+  const file = cacheFile();
+  await fs.mkdir(join(homedir(), ".config", "superhuman-cli"), { recursive: true });
+  await fs.writeFile(file, JSON.stringify(map, null, 2), { mode: 0o600 });
+}
+
+function isFresh(tok: OwaToken | undefined): tok is OwaToken {
+  return !!tok && tok.expiresOn - Date.now() > EXPIRY_BUFFER_MS;
+}
+
+/** Decode a JWT payload without verifying (we only read claims we already trust). */
+function decodeJwt(jwt: string): Record<string, any> {
+  const seg = jwt.split(".")[1];
+  if (!seg) return {};
+  const b64 = seg.replace(/-/g, "+").replace(/_/g, "/");
+  const pad = b64 + "=".repeat((4 - (b64.length % 4)) % 4);
+  try {
+    return JSON.parse(Buffer.from(pad, "base64").toString("utf8"));
+  } catch {
+    return {};
+  }
+}
+
+/** The in-page function that mines the MSAL cache for the OWA mail token. */
+const READ_MSAL_EXPR = `(function () {
+  for (let i = 0; i < localStorage.length; i++) {
+    const k = localStorage.key(i);
+    let v = localStorage.getItem(k);
+    try {
+      const o = JSON.parse(v);
+      if (
+        o && typeof o.credentialType === "string" &&
+        o.credentialType.indexOf("AccessToken") === 0 &&
+        typeof o.target === "string" &&
+        o.target.indexOf("https://outlook.office.com/Mail.ReadWrite") !== -1 &&
+        o.secret
+      ) {
+        return JSON.stringify({ secret: o.secret, expiresOn: o.expiresOn });
+      }
+    } catch (e) {}
+  }
+  return null;
+})()`;
+
+interface OwaCdpTarget {
+  id: string;
+  url: string;
+}
+
+/** Find the logged-in Outlook Web page target on the running CDP browser. */
+async function findOwaTarget(
+  host: string,
+  port: number
+): Promise<OwaCdpTarget | null> {
+  let targets: any[];
+  try {
+    targets = (await CDP.List({ host, port })) as any[];
+  } catch {
+    return null;
+  }
+  const owa = targets.find(
+    (t) =>
+      t?.type === "page" &&
+      typeof t.url === "string" &&
+      OWA_HOSTS.some((h) => hostMatches(t.url, h))
+  );
+  return owa ? { id: owa.id, url: owa.url } : null;
+}
+
+/** Read the token from the OWA tab's MSAL cache, optionally reloading first. */
+async function scrapeToken(
+  host: string,
+  port: number,
+  target: OwaCdpTarget,
+  reload: boolean
+): Promise<OwaToken | null> {
+  const client = await CDP({ target: target.id, host, port });
+  try {
+    if (reload) {
+      await client.Page.enable();
+      await client.Page.reload({ ignoreCache: false });
+      await new Promise((r) => setTimeout(r, RELOAD_SETTLE_MS));
+    }
+    const { result, exceptionDetails } = await client.Runtime.evaluate({
+      expression: READ_MSAL_EXPR,
+      returnByValue: true,
+    });
+    if (exceptionDetails || !result?.value) return null;
+    const parsed = JSON.parse(result.value as string) as {
+      secret: string;
+      expiresOn: string | number;
+    };
+    const claims = decodeJwt(parsed.secret);
+    const email: string = claims.upn || claims.unique_name || claims.preferred_username || "";
+    const expiresOn = Number(parsed.expiresOn) * 1000;
+    if (!email || !Number.isFinite(expiresOn)) return null;
+    return { accessToken: parsed.secret, email, expiresOn };
+  } finally {
+    await client.close().catch(() => {});
+  }
+}
+
+/**
+ * Get a valid OWA access token for `email` (or the only OWA account if omitted).
+ *
+ * Resolution order: in-memory cache → disk cache → scrape MSAL cache from the
+ * live OWA tab → (if stale) reload the tab and re-scrape.
+ */
+export async function getOwaToken(email?: string): Promise<OwaToken> {
+  const key = email?.toLowerCase();
+
+  // 1. memory
+  if (key && isFresh(memCache.get(key))) return memCache.get(key)!;
+
+  // 2. disk
+  const disk = await loadDiskCache();
+  if (key && isFresh(disk[key])) {
+    memCache.set(key, disk[key]!);
+    return disk[key]!;
+  }
+  if (!key) {
+    const fresh = Object.values(disk).find(isFresh);
+    if (fresh) {
+      memCache.set(fresh.email.toLowerCase(), fresh);
+      return fresh;
+    }
+  }
+
+  // 3. scrape the live OWA session
+  const host = getCDPHost();
+  const ports = cdpPortCandidates();
+  let target: OwaCdpTarget | null = null;
+  let usedPort = 0;
+  for (const port of ports) {
+    target = await findOwaTarget(host, port);
+    if (target) {
+      usedPort = port;
+      break;
+    }
+  }
+  if (!target) {
+    throw new Error(
+      "No Outlook Web tab found on the CDP browser. Open https://outlook.office.com " +
+        "in the debugging browser (port 9222) and sign in, then retry."
+    );
+  }
+
+  let tok = await scrapeToken(host, usedPort, target, false);
+  // 4. stale or missing → reload the tab to force a silent re-mint, re-scrape
+  if (!isFresh(tok ?? undefined)) {
+    tok = await scrapeToken(host, usedPort, target, true);
+  }
+  if (!isFresh(tok ?? undefined)) {
+    throw new Error(
+      "Outlook Web session token is missing or expired. Open/refresh Outlook Web in " +
+        "the browser (sign in if prompted), then retry."
+    );
+  }
+
+  const token = tok!;
+  memCache.set(token.email.toLowerCase(), token);
+  disk[token.email.toLowerCase()] = token;
+  await saveDiskCache(disk).catch(() => {});
+  return token;
+}
+
+/** List OWA account emails known to the broker (from disk cache). */
+export async function listOwaAccounts(): Promise<string[]> {
+  const disk = await loadDiskCache();
+  return Object.values(disk).map((t) => t.email);
+}

--- a/src/owa-token.ts
+++ b/src/owa-token.ts
@@ -224,6 +224,11 @@ export async function getOwaToken(email?: string): Promise<OwaToken> {
   return token;
 }
 
+/** Clear the in-memory token cache. Tests only (disk cache is separate). */
+export function clearOwaMemCacheForTest(): void {
+  memCache.clear();
+}
+
 /** List OWA account emails known to the broker (from disk cache). */
 export async function listOwaAccounts(): Promise<string[]> {
   const disk = await loadDiskCache();

--- a/src/owa-token.ts
+++ b/src/owa-token.ts
@@ -38,8 +38,16 @@ export interface OwaToken {
 
 const memCache = new Map<string, OwaToken>();
 
+/** Config dir — honors SUPERHUMAN_CLI_CONFIG_DIR so tests stay isolated. */
+function configDir(): string {
+  return (
+    process.env.SUPERHUMAN_CLI_CONFIG_DIR ||
+    join(homedir(), ".config", "superhuman-cli")
+  );
+}
+
 function cacheFile(): string {
-  return join(homedir(), ".config", "superhuman-cli", "owa-tokens.json");
+  return join(configDir(), "owa-tokens.json");
 }
 
 async function loadDiskCache(): Promise<Record<string, OwaToken>> {
@@ -52,7 +60,7 @@ async function loadDiskCache(): Promise<Record<string, OwaToken>> {
 
 async function saveDiskCache(map: Record<string, OwaToken>): Promise<void> {
   const file = cacheFile();
-  await fs.mkdir(join(homedir(), ".config", "superhuman-cli"), { recursive: true });
+  await fs.mkdir(configDir(), { recursive: true });
   await fs.writeFile(file, JSON.stringify(map, null, 2), { mode: 0o600 });
 }
 

--- a/src/providers/outlook-draft-provider.ts
+++ b/src/providers/outlook-draft-provider.ts
@@ -1,0 +1,27 @@
+/**
+ * Outlook Web Native Draft Provider
+ *
+ * Lists drafts from the Outlook Drafts folder via the Outlook REST backend
+ * (the first-party OWA token), mapped to the unified Draft shape. Sibling to
+ * SuperhumanDraftProvider for `draft list` on Microsoft accounts.
+ */
+
+import type { Draft, IDraftProvider } from "../services/draft-service";
+import type { OutlookWebProvider } from "../outlook-web-provider";
+import { owaListDrafts, owaDelete } from "../outlook-rest-api";
+
+export class OutlookDraftProvider implements IDraftProvider {
+  readonly source: Draft["source"] = "native";
+
+  constructor(private provider: OutlookWebProvider) {}
+
+  async listDrafts(limit: number = 50): Promise<Draft[]> {
+    return owaListDrafts(this.provider.fetcher(), limit);
+  }
+
+  /** Delete a draft (move to Deleted Items — never a hard delete). */
+  async deleteDraft(draftId: string): Promise<boolean> {
+    await owaDelete(this.provider.fetcher(), [draftId]);
+    return true;
+  }
+}

--- a/src/read.ts
+++ b/src/read.ts
@@ -7,6 +7,8 @@
 
 import type { ConnectionProvider } from "./connection-provider";
 import { SuperhumanProvider } from "./superhuman-provider";
+import { OutlookWebProvider } from "./outlook-web-provider";
+import { owaGetThread } from "./outlook-rest-api";
 import { readThreadFromDB, getThreadBodiesFromDB } from "./sqlite-search";
 import { getCachedToken, loadTokensFromDisk } from "./token-api";
 
@@ -463,6 +465,9 @@ export async function readThread(
   provider: ConnectionProvider,
   threadId: string
 ): Promise<ThreadMessage[]> {
+  if (provider instanceof OutlookWebProvider) {
+    return owaGetThread(provider.fetcher(), threadId);
+  }
   if (provider instanceof SuperhumanProvider) {
     return readThreadSuperhuman(provider, threadId);
   }

--- a/src/token-api.ts
+++ b/src/token-api.ts
@@ -41,6 +41,14 @@ export interface TokenInfo {
   expires: number;
   /** @deprecated SuperhumanProvider is provider-agnostic; retained for CachedTokenProvider compat */
   isMicrosoft: boolean;
+  /**
+   * True when `accessToken` is an Outlook Web (OWA) first-party session token
+   * (aud=outlook.office.com), brokered from the live OWA tab rather than issued
+   * by Superhuman. Verbs branch on this to route to the Outlook REST backend
+   * instead of MS Graph / the Superhuman backend. Always accompanies
+   * `isMicrosoft: true`.
+   */
+  isOutlookWeb?: boolean;
   /** @deprecated OAuth refresh token — not needed for Superhuman JWT flow */
   refreshToken?: string;
   // Superhuman backend API fields


### PR DESCRIPTION
## Why

UVA revoked Superhuman's access to the M365 tenant and gates third-party mail apps behind **admin consent** (verified: a device-code flow with the Thunderbird public client id returns "need admin approval"). Neither the cached Superhuman token (expired, revoked app) nor morgen's connection (no `Mail.*` scope, token not local) can be reused.

The only **no-new-OAuth** path is to piggyback the already-authenticated **Outlook Web** session running in the CDP browser — the same CDP-driven model Superhuman itself used. OWA's own first-party token ("One Outlook Web", `aud=outlook.office.com`) carries `Mail.ReadWrite` + `Mail.Send` and lasts ~24h, silently re-minted by MSAL while the browser stays signed in.

Feasibility is fully proven live: token capture, `GET /me`, inbox read, and a draft create→verify→delete round-trip all succeed with zero consent prompts.

## Approach

Add an `outlook-web` backend as a sibling to the Superhuman provider. Microsoft accounts route to it automatically (`token.isMicrosoft`); Google accounts stay on Superhuman untouched. Verbs branch on `provider instanceof OutlookWebProvider` and call Outlook REST (`outlook.office.com/api/v2.0`), returning the **exact** existing JSON shapes so every downstream consumer and the `email-handling` skill keep working.

## Status — landing incrementally (draft)

- [x] `src/owa-token.ts` — token broker (reads OWA's MSAL localStorage token over CDP; disk cache; reload-to-refresh). **Verified live** (`/me` → 200).
- [x] `OUTLOOK_WEB_BACKEND_SPEC.md` — full spec: provider seam, per-verb REST recipes, output contracts, file plan, tests.
- [ ] `src/outlook-rest-api.ts` — per-verb data functions
- [ ] `src/outlook-web-provider.ts` + routing in `connection-provider.ts`
- [ ] per-verb branches (inbox, read, search, send/draft/reply/forward, archive/delete, mark, star, label, snooze, calendar, attachments, contacts, export)
- [ ] `cdp-endpoint.ts` OWA target recognition
- [ ] tests (`bun test`), full parity, Google path stays green

Snippets / AI (Superhuman-only) degrade gracefully to "not available on outlook-web".

🤖 Generated with [Claude Code](https://claude.com/claude-code)