### PR TITLE
fix(outlook-web): use cached token by SMTP address + bound CDP ops

### DIFF
--- a/src/__tests__/outlook-token.test.ts
+++ b/src/__tests__/outlook-token.test.ts
@@ -85,3 +85,59 @@ describe("getOwaToken (disk-cache hit)", () => {
     expect(tok.email).toBe("ehu@law.virginia.edu");
   });
 });
+
+describe("getOwaToken (single-session fallback: UPN cache key vs SMTP --account)", () => {
+  test("a non-matching SMTP address reuses the single fresh token (no CDP scrape)", async () => {
+    // The token is keyed by its UPN, but the caller asks by SMTP address —
+    // the two identify the same one signed-in mailbox. Must NOT re-scrape.
+    const expiresOn = Date.now() + 3600_000;
+    await seed({
+      "vwh7mb@lawschool.virginia.edu": {
+        accessToken: "the-token",
+        email: "vwh7mb@lawschool.virginia.edu",
+        expiresOn,
+      },
+    });
+    const tok = await getOwaToken("ehu@law.virginia.edu");
+    expect(tok.accessToken).toBe("the-token");
+    expect(tok.email).toBe("vwh7mb@lawschool.virginia.edu");
+  });
+
+  test("aliases the requested SMTP address to the token so the next lookup hits directly", async () => {
+    const expiresOn = Date.now() + 3600_000;
+    await seed({
+      "vwh7mb@lawschool.virginia.edu": {
+        accessToken: "the-token",
+        email: "vwh7mb@lawschool.virginia.edu",
+        expiresOn,
+      },
+    });
+    await getOwaToken("ehu@law.virginia.edu");
+    // The disk cache should now also be keyed by the SMTP address.
+    expect(await listOwaAccounts()).toContain("vwh7mb@lawschool.virginia.edu");
+    const raw = JSON.parse(
+      await Bun.file(join(dir, "owa-tokens.json")).text()
+    );
+    expect(raw["ehu@law.virginia.edu"]?.accessToken).toBe("the-token");
+  });
+
+  test("with several fresh tokens it does NOT guess — falls through to the (absent) CDP scrape", async () => {
+    // Ambiguous: two mailboxes, neither matches the requested key. We must not
+    // silently return the wrong one; with no browser this surfaces as an error.
+    const expiresOn = Date.now() + 3600_000;
+    await seed({
+      "a@x.com": { accessToken: "a", email: "a@x.com", expiresOn },
+      "b@y.com": { accessToken: "b", email: "b@y.com", expiresOn },
+    });
+    // Pin CDP to a dead port so the scrape fails fast and never touches a real
+    // browser that may be running on the default port.
+    const priorPort = process.env.CDP_PORT;
+    process.env.CDP_PORT = "59999";
+    try {
+      await expect(getOwaToken("c@z.com")).rejects.toThrow();
+    } finally {
+      if (priorPort === undefined) delete process.env.CDP_PORT;
+      else process.env.CDP_PORT = priorPort;
+    }
+  });
+});

--- a/src/owa-token.ts
+++ b/src/owa-token.ts
@@ -28,6 +28,39 @@ const EXPIRY_BUFFER_MS = 5 * 60 * 1000;
 /** How long to wait after a tab reload for OWA to bootstrap + re-mint the token. */
 const RELOAD_SETTLE_MS = 4500;
 
+/** Upper bound on any single CDP round-trip, so a wedged tab fails fast. */
+const CDP_OP_TIMEOUT_MS = 10_000;
+
+/**
+ * Reject rather than wait forever. A wedged Outlook Web tab (renderer busy,
+ * mid-navigation, or crashed) answers /json but never responds to
+ * Runtime.evaluate/Page.reload — an unbounded await there hangs the whole CLI.
+ */
+function withTimeout<T>(p: Promise<T>, what: string, ms = CDP_OP_TIMEOUT_MS): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(
+      () =>
+        reject(
+          new Error(
+            `${what} timed out after ${ms}ms — the Outlook Web tab is unresponsive. ` +
+              "Refresh/reopen Outlook Web in the browser, then retry."
+          )
+        ),
+      ms
+    );
+    p.then(
+      (v) => {
+        clearTimeout(timer);
+        resolve(v);
+      },
+      (e) => {
+        clearTimeout(timer);
+        reject(e);
+      }
+    );
+  });
+}
+
 export interface OwaToken {
   accessToken: string;
   /** Account UPN / email, decoded from the token's `upn` claim. */
@@ -114,7 +147,10 @@ async function findOwaTarget(
 ): Promise<OwaCdpTarget | null> {
   let targets: any[];
   try {
-    targets = (await CDP.List({ host, port })) as any[];
+    targets = (await withTimeout(
+      CDP.List({ host, port }) as Promise<any[]>,
+      `CDP target list on port ${port}`
+    )) as any[];
   } catch {
     return null;
   }
@@ -134,17 +170,23 @@ async function scrapeToken(
   target: OwaCdpTarget,
   reload: boolean
 ): Promise<OwaToken | null> {
-  const client = await CDP({ target: target.id, host, port });
+  const client = await withTimeout(
+    CDP({ target: target.id, host, port }),
+    "CDP attach to Outlook Web tab"
+  );
   try {
     if (reload) {
-      await client.Page.enable();
-      await client.Page.reload({ ignoreCache: false });
+      await withTimeout(client.Page.enable(), "Page.enable");
+      await withTimeout(client.Page.reload({ ignoreCache: false }), "Page.reload");
       await new Promise((r) => setTimeout(r, RELOAD_SETTLE_MS));
     }
-    const { result, exceptionDetails } = await client.Runtime.evaluate({
-      expression: READ_MSAL_EXPR,
-      returnByValue: true,
-    });
+    const { result, exceptionDetails } = await withTimeout(
+      client.Runtime.evaluate({
+        expression: READ_MSAL_EXPR,
+        returnByValue: true,
+      }),
+      "reading the Outlook Web token"
+    );
     if (exceptionDetails || !result?.value) return null;
     const parsed = JSON.parse(result.value as string) as {
       secret: string;
@@ -178,12 +220,24 @@ export async function getOwaToken(email?: string): Promise<OwaToken> {
     memCache.set(key, disk[key]!);
     return disk[key]!;
   }
-  if (!key) {
-    const fresh = Object.values(disk).find(isFresh);
-    if (fresh) {
-      memCache.set(fresh.email.toLowerCase(), fresh);
-      return fresh;
+  // Single-session fallback. The OWA piggyback rides ONE signed-in browser
+  // session, but callers identify the mailbox by its SMTP address
+  // (--account ehu@law.virginia.edu) while the token is keyed by the UPN from
+  // its `upn` claim (vwh7mb@lawschool.virginia.edu). When the requested key
+  // doesn't match, reuse the single fresh cached token rather than needlessly
+  // re-scraping CDP every call (or hanging on a wedged tab). Only when exactly
+  // one fresh token exists — with several we can't safely guess which mailbox.
+  const freshTokens = Object.values(disk).filter(isFresh);
+  if (freshTokens.length === 1) {
+    const only = freshTokens[0]!;
+    memCache.set(only.email.toLowerCase(), only);
+    if (key) {
+      // Alias the requested address to this token so the next call hits directly.
+      disk[key] = only;
+      memCache.set(key, only);
+      await saveDiskCache(disk).catch(() => {});
     }
+    return only;
   }
 
   // 3. scrape the live OWA session
@@ -220,6 +274,12 @@ export async function getOwaToken(email?: string): Promise<OwaToken> {
   const token = tok!;
   memCache.set(token.email.toLowerCase(), token);
   disk[token.email.toLowerCase()] = token;
+  // Also store under the requested address (SMTP) so later lookups by --account
+  // hit the disk cache directly instead of re-scraping (UPN != SMTP).
+  if (key && key !== token.email.toLowerCase()) {
+    memCache.set(key, token);
+    disk[key] = token;
+  }
   await saveDiskCache(disk).catch(() => {});
   return token;
 }


### PR DESCRIPTION
Follow-up to #31. Two robustness bugs in the OWA token broker, found while live-testing the merged backend:

## 1. Cache-key mismatch → re-scraped CDP on every call
The broker caches the token under its **UPN** (`upn` claim, e.g. `vwh7mb@lawschool.virginia.edu`) but the CLI looks it up by the `--account` **SMTP** address (`ehu@law.virginia.edu`). They never match, so the disk cache was always a miss and every command did a fresh CDP scrape (slow, and fragile if the tab is busy).

**Fix:** single-session fallback — when the requested key doesn't match, reuse the one fresh cached token (the OWA piggyback rides a single signed-in session), but **only when exactly one exists** so we never guess among multiple mailboxes. Alias the requested address to the token so later lookups hit disk directly.

## 2. No timeout on CDP ops → infinite hang on a wedged tab
A busy/mid-navigation Outlook Web tab answers `/json` but never responds to `Runtime.evaluate`/`Page.reload`, hanging the whole CLI indefinitely.

**Fix:** wrap `CDP.List`, the attach, `Page.enable`/`reload`, and `Runtime.evaluate` in a 10s `withTimeout` that fails with an actionable "refresh/reopen Outlook Web" message.

## Net effect
Once a token is cached, commands read it from disk (~24h) and **never touch the browser** — so a wedged/closed tab no longer blocks reads, and when a scrape *is* needed it fails fast with a clear message instead of hanging.

## Verification
- Live: `inbox --account ehu@law.virginia.edu --json` returns from the cached token in **2ms** even with the OWA tab unresponsive (previously hung indefinitely).
- `tsc --noEmit` clean; full `bun test` = **502 pass / 1 skip / 1 fail** (+3 new broker tests). The 1 failure is the pre-existing date-dependent `parseSendAtTime` test (Monday-only), identical to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)