### PR TITLE
feat(outlook-web): make Superhuman primary, Outlook Web the auto-fallback

### DIFF
--- a/src/__tests__/outlook-web-provider.test.ts
+++ b/src/__tests__/outlook-web-provider.test.ts
@@ -30,10 +30,20 @@ const HAD_CONFIG_DIR = Object.prototype.hasOwnProperty.call(
   "SUPERHUMAN_CLI_CONFIG_DIR"
 );
 const PRIOR_CONFIG_DIR = process.env.SUPERHUMAN_CLI_CONFIG_DIR;
+const HAD_MS_BACKEND = Object.prototype.hasOwnProperty.call(
+  process.env,
+  "SUPERHUMAN_CLI_MS_BACKEND"
+);
+const PRIOR_MS_BACKEND = process.env.SUPERHUMAN_CLI_MS_BACKEND;
 
 function restoreConfigDir() {
   if (HAD_CONFIG_DIR) process.env.SUPERHUMAN_CLI_CONFIG_DIR = PRIOR_CONFIG_DIR;
   else delete process.env.SUPERHUMAN_CLI_CONFIG_DIR;
+}
+
+function restoreMsBackend() {
+  if (HAD_MS_BACKEND) process.env.SUPERHUMAN_CLI_MS_BACKEND = PRIOR_MS_BACKEND;
+  else delete process.env.SUPERHUMAN_CLI_MS_BACKEND;
 }
 
 function seedOwaCache(map: Record<string, any>) {
@@ -48,6 +58,7 @@ function clearOwaCache() {
 
 beforeEach(() => {
   process.env.SUPERHUMAN_CLI_CONFIG_DIR = TEST_DIR;
+  delete process.env.SUPERHUMAN_CLI_MS_BACKEND; // default to "auto" unless a test sets it
   clearTokenCache();
   clearOwaMemCacheForTest();
   clearOwaCache();
@@ -58,6 +69,7 @@ afterEach(() => {
   clearOwaMemCacheForTest();
   clearOwaCache();
   restoreConfigDir();
+  restoreMsBackend();
 });
 
 afterAll(() => {
@@ -65,37 +77,63 @@ afterAll(() => {
   clearTokenCache();
   clearOwaMemCacheForTest();
   restoreConfigDir();
+  restoreMsBackend();
   try {
     rmSync(TEST_DIR, { recursive: true, force: true });
   } catch {}
 });
 
-describe("providerFromToken: Microsoft -> OutlookWebProvider", () => {
-  test("a microsoft cached token routes to OutlookWebProvider", async () => {
-    const token: TokenInfo = {
-      accessToken: "dead-oauth",
-      email: "ehu@law.virginia.edu",
-      expires: Date.now() + 3600_000,
-      isMicrosoft: true,
-    };
-    setTokenCacheForTest(token.email, token);
+describe("providerFromToken: Microsoft primary=Superhuman, fallback=OWA", () => {
+  const msToken = (sh?: { token: string; expires: number }): TokenInfo => ({
+    accessToken: "oauth",
+    email: "ehu@law.virginia.edu",
+    expires: Date.now() + 3600_000,
+    isMicrosoft: true,
+    ...(sh ? { superhumanToken: sh } : {}),
+  });
 
+  test("microsoft with NO superhuman token falls back to OutlookWebProvider", async () => {
+    setTokenCacheForTest("ehu@law.virginia.edu", msToken());
     const provider = await resolveProvider({ account: "ehu@law.virginia.edu" });
     expect(provider).toBeInstanceOf(OutlookWebProvider);
   });
 
-  test("microsoft wins even when a (stale) superhumanToken is present", async () => {
-    const token: TokenInfo = {
-      accessToken: "dead-oauth",
-      email: "ehu@law.virginia.edu",
-      expires: Date.now() + 3600_000,
-      isMicrosoft: true,
-      superhumanToken: { token: "stale-dead-jwt", expires: Date.now() + 3600_000 },
-    };
-    setTokenCacheForTest(token.email, token);
-
+  test("microsoft with an EXPIRED superhuman token (revoked tenant) falls back to OWA", async () => {
+    setTokenCacheForTest(
+      "ehu@law.virginia.edu",
+      msToken({ token: "revoked-jwt", expires: Date.now() - 1000 })
+    );
     const provider = await resolveProvider({ account: "ehu@law.virginia.edu" });
     expect(provider).toBeInstanceOf(OutlookWebProvider);
+  });
+
+  test("microsoft with a VALID superhuman token uses Superhuman (primary)", async () => {
+    setTokenCacheForTest(
+      "ehu@law.virginia.edu",
+      msToken({ token: "good-jwt", expires: Date.now() + 3600_000 })
+    );
+    const provider = await resolveProvider({ account: "ehu@law.virginia.edu" });
+    expect(provider).toBeInstanceOf(SuperhumanProvider);
+  });
+
+  test("SUPERHUMAN_CLI_MS_BACKEND=outlook-web forces OWA even with a valid SH token", async () => {
+    process.env.SUPERHUMAN_CLI_MS_BACKEND = "outlook-web";
+    setTokenCacheForTest(
+      "ehu@law.virginia.edu",
+      msToken({ token: "good-jwt", expires: Date.now() + 3600_000 })
+    );
+    const provider = await resolveProvider({ account: "ehu@law.virginia.edu" });
+    expect(provider).toBeInstanceOf(OutlookWebProvider);
+  });
+
+  test("SUPERHUMAN_CLI_MS_BACKEND=superhuman forces Superhuman even with an expired token", async () => {
+    process.env.SUPERHUMAN_CLI_MS_BACKEND = "superhuman";
+    setTokenCacheForTest(
+      "ehu@law.virginia.edu",
+      msToken({ token: "jwt", expires: Date.now() - 1000 })
+    );
+    const provider = await resolveProvider({ account: "ehu@law.virginia.edu" });
+    expect(provider).toBeInstanceOf(SuperhumanProvider);
   });
 
   test("a google token still routes to SuperhumanProvider (no regression)", async () => {

--- a/src/connection-provider.ts
+++ b/src/connection-provider.ts
@@ -140,22 +140,60 @@ export class CDPConnectionProvider implements ConnectionProvider {
  * If the token has a superhumanToken, return SuperhumanProvider;
  * otherwise fall back to CachedTokenProvider for backward compat.
  */
+/**
+ * Microsoft-account backend preference. Superhuman is the PRIMARY backend;
+ * Outlook Web (OWA) is the automatic FALLBACK. Override with the env var
+ * SUPERHUMAN_CLI_MS_BACKEND:
+ *   - "auto" (default): use Superhuman when its token is usable, else OWA.
+ *   - "superhuman": force Superhuman (falls back to OWA only if no SH token exists).
+ *   - "outlook-web": force OWA.
+ */
+function msBackendPreference(): "auto" | "superhuman" | "outlook-web" {
+  const v = (process.env.SUPERHUMAN_CLI_MS_BACKEND || "auto").toLowerCase();
+  return v === "superhuman" || v === "outlook-web" ? v : "auto";
+}
+
+/**
+ * Is the cached Superhuman token present and not (near) expired? A revoked
+ * tenant (e.g. UVA pulling Superhuman) leaves an expired superhumanToken that
+ * cannot refresh — that's the signal to fall back to OWA. A missing expiry is
+ * treated as usable (SuperhumanProvider refreshes on 401).
+ */
+function superhumanTokenUsable(token: TokenInfo): boolean {
+  const sh = token.superhumanToken;
+  if (!sh?.token) return false;
+  return sh.expires == null || sh.expires > Date.now() + 60_000;
+}
+
+function makeSuperhumanProvider(token: TokenInfo): SuperhumanProvider {
+  const shTokenInfo: SuperhumanTokenInfo = {
+    token: token.superhumanToken!.token,
+    email: token.email,
+    expires: token.superhumanToken!.expires,
+    userPrefix: token.userPrefix,
+  };
+  return new SuperhumanProvider(shTokenInfo);
+}
+
+/**
+ * Build the best provider from a cached TokenInfo.
+ *
+ * Microsoft accounts: Superhuman is PRIMARY, Outlook Web is the automatic
+ * FALLBACK (used when the Superhuman token is unusable — e.g. the tenant
+ * revoked Superhuman). So when IT re-approves Superhuman and the token
+ * refreshes, routing switches back to Superhuman with no code change.
+ * Google accounts are unchanged (Superhuman when a token exists).
+ */
 function providerFromToken(token: TokenInfo, email: string): ConnectionProvider {
-  // Microsoft accounts route to the Outlook Web backend (the first-party OWA
-  // token), BEFORE the superhumanToken check — the stale MS entry in tokens.json
-  // still carries a dead superhumanToken that must not win. Google accounts are
-  // untouched and still use Superhuman.
   if (token.isMicrosoft) {
+    const pref = msBackendPreference();
+    if (pref === "outlook-web") return new OutlookWebProvider(token.email || email);
+    if (pref === "superhuman" && token.superhumanToken) return makeSuperhumanProvider(token);
+    if (pref === "auto" && superhumanTokenUsable(token)) return makeSuperhumanProvider(token);
     return new OutlookWebProvider(token.email || email);
   }
   if (token.superhumanToken) {
-    const shTokenInfo: SuperhumanTokenInfo = {
-      token: token.superhumanToken.token,
-      email: token.email,
-      expires: token.superhumanToken.expires,
-      userPrefix: token.userPrefix,
-    };
-    return new SuperhumanProvider(shTokenInfo);
+    return makeSuperhumanProvider(token);
   }
   return new CachedTokenProvider(email);
 }


### PR DESCRIPTION
Follow-up to #31/#32. Per the mailbox owner's intent: **Superhuman is the primary backend for Microsoft accounts, Outlook Web is the automatic backup** — anticipating that IT re-approves Superhuman at some point.

## Behavior
- **`auto` (default):** use Superhuman when its `superhumanToken` is present and unexpired; otherwise fall back to OWA. A revoked tenant leaves an expired token that can't refresh → OWA. When Superhuman is re-approved and the user re-auths (fresh token) → routing switches back to Superhuman automatically, no code change or reinstall.
- **`SUPERHUMAN_CLI_MS_BACKEND=superhuman`** — force Superhuman.
- **`SUPERHUMAN_CLI_MS_BACKEND=outlook-web`** — force OWA.

Google accounts unchanged.

## Verification
- Live (today, Superhuman revoked → SH token expired): `inbox --account ehu@law.virginia.edu` still routes through OWA and works.
- `tsc --noEmit` clean; full `bun test` **506 pass / 1 skip / 0 fail**; +6 routing tests covering NO-token / expired-token / valid-token selection and both env overrides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)