### PR TITLE
feat(outlook-web): support --attach on reply/reply-all/forward/draft/send

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,9 +210,11 @@ superhuman account auth   # refresh the Superhuman token → back on Superhuman
 
 All the usual verbs (`inbox`, `read`, `search`, `send`, `reply`, `archive`,
 `star`, `label`, `calendar`, `attachment`, `contact`, …) work the same via
-`--account`. A few Superhuman-only features (AI search, snippets, snooze,
-sending with attachments) report that they are unavailable on Outlook Web
-accounts.
+`--account`. Outbound attachments (`--attach` on `send`, `reply`, `reply-all`,
+`forward`, `draft`) work too — each file is POSTed to the draft as an inline
+base64 `FileAttachment`, capped at 25MB per file since the Outlook REST v2.0
+endpoint has no upload-session route. A few Superhuman-only features (AI search,
+snippets, snooze) report that they are unavailable on Outlook Web accounts.
 
 ### Composing Email
 

--- a/src/__tests__/outlook-rest-api.test.ts
+++ b/src/__tests__/outlook-rest-api.test.ts
@@ -26,6 +26,8 @@ import {
   owaRemoveLabel,
   owaListEvents,
   owaListAttachments,
+  owaAddAttachment,
+  OWA_MAX_ATTACHMENT_BYTES,
   owaContacts,
   owaListDrafts,
   type OwaFetcher,
@@ -382,6 +384,34 @@ describe("owaListAttachments", () => {
       threadId: "msgX",
       inline: false,
     });
+  });
+});
+
+describe("owaAddAttachment", () => {
+  test("POSTs an inline base64 FileAttachment to the draft", async () => {
+    const { fn, calls } = makeFetcher(() => ({ Id: "att1" }));
+    await owaAddAttachment(fn, "draft1", {
+      name: "note.eml",
+      mimeType: "message/rfc822",
+      base64: "QUJD",
+    });
+    expect(calls[0]!.method).toBe("POST");
+    expect(calls[0]!.path).toBe("/messages/draft1/attachments");
+    expect(calls[0]!.body).toEqual({
+      "@odata.type": "#Microsoft.OutlookServices.FileAttachment",
+      Name: "note.eml",
+      ContentType: "message/rfc822",
+      ContentBytes: "QUJD",
+    });
+  });
+
+  test("rejects files over the inline POST ceiling without calling the API", async () => {
+    const { fn, calls } = makeFetcher(() => ({}));
+    const oversized = "A".repeat(Math.ceil(((OWA_MAX_ATTACHMENT_BYTES + 1024 * 1024) * 4) / 3));
+    await expect(
+      owaAddAttachment(fn, "draft1", { name: "big.bin", mimeType: "application/octet-stream", base64: oversized })
+    ).rejects.toThrow(/big\.bin is .*MB/);
+    expect(calls).toHaveLength(0);
   });
 });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -86,8 +86,10 @@ import {
   owaForward,
   owaSendDraft,
   owaSendNew,
+  owaAddAttachment,
   owaContacts,
   owaListDrafts,
+  type OwaFetcher,
 } from "./outlook-rest-api";
 import { DraftService, type Draft } from "./services/draft-service";
 import { SuperhumanDraftProvider } from "./providers/superhuman-draft-provider";
@@ -1224,6 +1226,26 @@ function owaUnsupported(verb: string): never {
   process.exit(1);
 }
 
+/**
+ * Attach `--attach` files to an Outlook draft (reply/forward/new). Each file is
+ * read from disk and POSTed to the draft's attachments collection. Errors abort
+ * the command so a draft never silently goes out missing its attachments.
+ */
+async function owaAttachFiles(
+  fetcher: OwaFetcher,
+  draftId: string,
+  files: string[] | undefined
+): Promise<void> {
+  for (const path of files || []) {
+    const file = await readFileAsBase64(path);
+    await owaAddAttachment(fetcher, draftId, {
+      name: file.filename,
+      mimeType: file.mimeType,
+      base64: file.base64Data,
+    });
+  }
+}
+
 /** Parse recipient strings into Outlook-friendly "Name <email>" / bare list. */
 function owaRecipients(list: string[]): string[] {
   return list.filter(Boolean);
@@ -1231,21 +1253,34 @@ function owaRecipients(list: string[]): string[] {
 
 // --- Outlook Web command handlers -----------------------------------------
 
-/** `send` on an OWA account: compose + send via Outlook REST (/sendmail). */
+/**
+ * `send` on an OWA account: compose + send via Outlook REST (/sendmail).
+ * With `--attach`, /sendmail is replaced by draft → attach → /send, since
+ * attachments are POSTed to a message that already exists server-side.
+ */
 async function cmdSendOwa(provider: OutlookWebProvider, options: CliOptions): Promise<void> {
-  if (options.attachFiles && options.attachFiles.length > 0) {
-    owaUnsupported("Sending with attachments");
-  }
   const html = options.html || textToHtml(options.body);
+  const fetcher = provider.fetcher();
+  const input = {
+    to: owaRecipients(options.to),
+    cc: owaRecipients(options.cc),
+    bcc: owaRecipients(options.bcc),
+    subject: options.subject || "",
+    body: html,
+    html: true,
+  };
   try {
-    await owaSendNew(provider.fetcher(), {
-      to: owaRecipients(options.to),
-      cc: owaRecipients(options.cc),
-      bcc: owaRecipients(options.bcc),
-      subject: options.subject || "",
-      body: html,
-      html: true,
-    });
+    if (options.attachFiles && options.attachFiles.length > 0) {
+      const draft = await owaCreateDraft(fetcher, input);
+      if (!draft.id) {
+        error("Failed to create draft for send");
+        process.exit(1);
+      }
+      await owaAttachFiles(fetcher, draft.id, options.attachFiles);
+      await owaSendDraft(fetcher, draft.id);
+    } else {
+      await owaSendNew(fetcher, input);
+    }
   } catch (e) {
     error(`Failed to send: ${(e as Error).message}`);
     process.exit(1);
@@ -1284,9 +1319,6 @@ async function cmdReplyOwa(
   options: CliOptions,
   all: boolean
 ): Promise<void> {
-  if (options.attachFiles && options.attachFiles.length > 0) {
-    owaUnsupported("Replying with attachments");
-  }
   const html = options.html || textToHtml(options.body || "");
   const fetcher = provider.fetcher();
   try {
@@ -1296,6 +1328,7 @@ async function cmdReplyOwa(
       process.exit(1);
     }
     await owaPatchRecipients(provider, draft.id, options);
+    await owaAttachFiles(fetcher, draft.id, options.attachFiles);
     if (options.send) {
       await owaSendDraft(fetcher, draft.id);
       success("Reply sent");
@@ -1312,9 +1345,6 @@ async function cmdReplyOwa(
 
 /** `forward` on an OWA account. */
 async function cmdForwardOwa(provider: OutlookWebProvider, options: CliOptions): Promise<void> {
-  if (options.attachFiles && options.attachFiles.length > 0) {
-    owaUnsupported("Forwarding with attachments");
-  }
   if (options.to.length === 0) {
     error("Forward requires at least one recipient (--to)");
     process.exit(1);
@@ -1331,6 +1361,7 @@ async function cmdForwardOwa(provider: OutlookWebProvider, options: CliOptions):
       error("Failed to create forward draft");
       process.exit(1);
     }
+    await owaAttachFiles(fetcher, draft.id, options.attachFiles);
     if (options.send) {
       await owaSendDraft(fetcher, draft.id);
       success("Forward sent");
@@ -1362,6 +1393,7 @@ async function cmdDraftOwa(provider: OutlookWebProvider, options: CliOptions): P
       if (Object.keys(patch).length > 0) {
         await provider.owaFetch("PATCH", `/messages/${encodeURIComponent(options.updateDraftId)}`, patch);
       }
+      await owaAttachFiles(fetcher, options.updateDraftId, options.attachFiles);
       success("Draft updated in Outlook");
       log(`  ${colors.dim}Draft ID: ${options.updateDraftId}${colors.reset}`);
     } catch (e) {
@@ -1372,9 +1404,6 @@ async function cmdDraftOwa(provider: OutlookWebProvider, options: CliOptions): P
   }
 
   requireAnyRecipient(options);
-  if (options.attachFiles && options.attachFiles.length > 0) {
-    owaUnsupported("Draft attachments");
-  }
   const html = options.html || textToHtml(options.body);
   try {
     const draft = await owaCreateDraft(fetcher, {
@@ -1385,6 +1414,7 @@ async function cmdDraftOwa(provider: OutlookWebProvider, options: CliOptions): P
       body: html,
       html: true,
     });
+    await owaAttachFiles(fetcher, draft.id, options.attachFiles);
     success("Draft created in Outlook");
     log(`  ${colors.dim}Draft ID: ${draft.id}${colors.reset}`);
     log(`  ${colors.dim}Account: ${await provider.getCurrentEmail()}${colors.reset}`);

--- a/src/outlook-rest-api.ts
+++ b/src/outlook-rest-api.ts
@@ -706,6 +706,39 @@ export async function owaListAttachments(
     }));
 }
 
+/**
+ * Upper bound on a single outbound attachment. Outlook REST v2.0 has no
+ * `createUploadSession` (verified live: 400 ErrorInvalidReferenceItem), so the
+ * inline POST below is the only route and oversized files must be rejected up
+ * front rather than failing mid-transfer.
+ */
+export const OWA_MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024;
+
+/**
+ * Attach a file to a draft: POST /messages/{id}/attachments with an inline
+ * base64 FileAttachment. `.eml` files go up with ContentType message/rfc822,
+ * which Outlook and Gmail both render as an attached message.
+ */
+export async function owaAddAttachment(
+  fetch: OwaFetcher,
+  draftId: string,
+  att: { name: string; mimeType: string; base64: string }
+): Promise<void> {
+  const bytes = Math.ceil((att.base64.length * 3) / 4);
+  if (bytes > OWA_MAX_ATTACHMENT_BYTES) {
+    throw new Error(
+      `${att.name} is ${(bytes / 1024 / 1024).toFixed(1)}MB — the Outlook Web backend can only ` +
+        `attach files up to ${OWA_MAX_ATTACHMENT_BYTES / 1024 / 1024}MB (no upload-session support).`
+    );
+  }
+  await fetch("POST", `/messages/${encodeURIComponent(draftId)}/attachments`, {
+    "@odata.type": "#Microsoft.OutlookServices.FileAttachment",
+    Name: att.name,
+    ContentType: att.mimeType,
+    ContentBytes: att.base64,
+  });
+}
+
 /** Download an attachment's bytes (base64). */
 export async function owaDownloadAttachment(
   fetch: OwaFetcher,


### PR DESCRIPTION
## What

`superhuman reply <id> --attach file.eml` on an outlook-web account failed with
*"Replying with attachments is not available on outlook-web accounts."* That guard
(`owaUnsupported`, src/cli.ts) was a placeholder from the initial OWA landing (#31),
not a real API limitation.

## The route exists

Outlook REST v2.0 (`https://outlook.office.com/api/v2.0/me`, the transport this backend
already uses with the first-party OWA session token) accepts:

```
POST /messages/{draftId}/attachments
{ "@odata.type": "#Microsoft.OutlookServices.FileAttachment",
  "Name": "...", "ContentType": "...", "ContentBytes": "<base64>" }
```

Verified live against the UVA tenant (drafts only, nothing sent):

- `createReply` → attach the 88KB `.eml` as `message/rfc822` → draft reports
  `HasAttachments: true`, attachment listed as `Superhuman-access-request-2026-07-19.eml
  (message/rfc822, 90459B)`. Same file also accepted as `application/octet-stream`;
  `message/rfc822` is the right one (already what `readFileAsBase64` maps `.eml` to) so
  Outlook/Gmail render it as an attached message rather than an opaque blob.
- 3MB / 4MB / 5MB blobs all POSTed fine (Graph docs state a 3MB ceiling for the direct
  POST; this tenant is more permissive).
- `createUploadSession` is **not** available on REST v2.0 (`400 ErrorInvalidReferenceItem`),
  so there is no large-file route — oversized files are rejected up front at 25MB with a
  clear message instead of failing mid-transfer.
- `#microsoft.graph.itemAttachment` is a Graph-only shape and unnecessary: the `.eml` as a
  `message/rfc822` fileAttachment is what the app itself produces.

Graph proper is not reachable here — the OWA token's `aud` is `https://outlook.office.com`.

## Changes

- `owaAddAttachment()` + `OWA_MAX_ATTACHMENT_BYTES` in `src/outlook-rest-api.ts`
- `owaAttachFiles()` in `src/cli.ts`, wired into `cmdReplyOwa`, `cmdForwardOwa`,
  `cmdDraftOwa` (create + update) and `cmdSendOwa`. `send --attach` switches from
  `/sendmail` to draft → attach → `/send`, since attachments need a server-side message.
- Four `owaUnsupported(...)` attachment guards removed; AI-search / snippets / snooze
  guards left alone.
- Gmail / native Superhuman paths untouched.

## Tests

- New `owaAddAttachment` unit tests (exact REST path/method/body; oversized file rejected
  without an API call).
- Full suite: 508 pass, 0 fail.
- E2E via the CLI itself: `superhuman reply <msg> --attach ...eml --body ...` created a
  real reply draft with the attachment; draft deleted afterwards. **No email was sent.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YamPXUQ2FwU1HgqQCW3kuh